### PR TITLE
Fix Windows portability across generation and transports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
-# Pin LF so the spec-bundle drift guard (src/server/worker.test.ts) compares
-# byte-identical text on every platform: readFileSync of a CRLF-normalized
-# *.yaml would not match the \n escapes baked into the generated bundle.
+# Pin generator inputs and outputs to LF so byte-identical drift guards behave
+# consistently on every platform. CRLF inputs alter embedded string escapes,
+# while CRLF generated modules do not match the LF output emitted by the generator.
 *.yaml text eol=lf
 *.yml text eol=lf
-src/server/spec-data.generated.ts text eol=lf
+docs/RESPONSIBLE_USE.md text eol=lf
+*.generated.ts text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,22 @@ jobs:
       - run: npm run check
       - run: npm run check:clinical-release
 
+  windows-portability:
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run check:generated
+      - run: npm run build
+      - run: npx vitest run test/transport/parity.e2e.test.ts
+
   docs:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/src/cli/bundle-specs.test.ts
+++ b/src/cli/bundle-specs.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { bundleSpecs } from './bundle-specs.js';
+import { bundleSpecs, normalizeLineEndings } from './bundle-specs.js';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '../..');
 
@@ -39,5 +39,19 @@ describe('generated compute index', () => {
     expect(reviewStates).toContain('"gfr"');
     expect(reviewStates).toContain('"state": "scenario_verified"');
     expect(reviewStates).not.toContain('"state": "blocked"');
+  });
+});
+
+describe('cross-platform generation', () => {
+  it('normalizes Windows and legacy line endings before embedding source text', () => {
+    expect(normalizeLineEndings('first\r\nsecond\rthird\n')).toBe(
+      'first\nsecond\nthird\n',
+    );
+  });
+
+  it('pins the generator input and all generated TypeScript artifacts to LF', () => {
+    const attributes = readFileSync(join(ROOT, '.gitattributes'), 'utf8');
+    expect(attributes).toContain('docs/RESPONSIBLE_USE.md text eol=lf');
+    expect(attributes).toContain('*.generated.ts text eol=lf');
   });
 });

--- a/src/cli/bundle-specs.ts
+++ b/src/cli/bundle-specs.ts
@@ -31,6 +31,10 @@ function outputIsCurrent(path: string, expected: string): boolean {
   return existsSync(path) && readFileSync(path, 'utf8') === expected;
 }
 
+export function normalizeLineEndings(text: string): string {
+  return text.replace(/\r\n?/g, '\n');
+}
+
 export async function bundleSpecs(argv: string[]): Promise<number> {
   const check = argv.includes('--check');
   const specsDir = join(ROOT, 'specs');
@@ -41,7 +45,9 @@ export async function bundleSpecs(argv: string[]): Promise<number> {
     JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')) as { version: string }
   ).version;
   const texts = Object.fromEntries(files.map((file) => [file, readFileSync(join(specsDir, file), 'utf8')]));
-  const responsibleUseText = readFileSync(join(ROOT, 'docs/RESPONSIBLE_USE.md'), 'utf8');
+  const responsibleUseText = normalizeLineEndings(
+    readFileSync(join(ROOT, 'docs/RESPONSIBLE_USE.md'), 'utf8'),
+  );
   const specs = [...validateSpecTexts(texts).values()];
 
   const entries = files.map(

--- a/src/engine/load-specs.test.ts
+++ b/src/engine/load-specs.test.ts
@@ -44,6 +44,22 @@ describe('strict spec authoring', () => {
     expect(() => validateSpecTexts(source())).not.toThrow();
   });
 
+  it('orders validated specs by filename regardless of source insertion order', () => {
+    const rFactor = structuredClone(validSpec);
+    rFactor.id = 'r_factor';
+    rFactor.clinicalModel.modelId = 'r_factor';
+    const ranson = structuredClone(validSpec);
+    ranson.id = 'ranson';
+    ranson.clinicalModel.modelId = 'ranson';
+
+    const specs = validateSpecTexts({
+      'ranson.yaml': stringify(ranson),
+      'r_factor.yaml': stringify(rFactor),
+    });
+
+    expect([...specs.keys()]).toEqual(['r_factor', 'ranson']);
+  });
+
   it.each([
     ['top-level', (spec: any) => { spec.unexpected = true; }],
     ['misspelled input', (spec: any) => { spec.inputs.value.hardLimit = [0, 1]; }],

--- a/src/engine/load-specs.ts
+++ b/src/engine/load-specs.ts
@@ -536,8 +536,11 @@ function lifecycleIssues(specs: ReadonlyMap<string, CalcSpec>): string[] {
 function validateSources(sources: [file: string, text: string][]): Map<string, CalcSpec> {
   const specs = new Map<string, CalcSpec>();
   const errors: string[] = [];
+  const orderedSources = [...sources].sort(([left], [right]) =>
+    left < right ? -1 : left > right ? 1 : 0,
+  );
 
-  for (const [file, text] of sources) {
+  for (const [file, text] of orderedSources) {
     let raw: unknown;
     try {
       raw = parseYaml(text);


### PR DESCRIPTION
## Summary

- normalize the Responsible Use source to LF before embedding it and pin all generator inputs and generated TypeScript artifacts to LF
- sort spec sources by filename at the shared validation boundary so Node and Worker catalogs register tools and resources identically
- add regression tests for CRLF normalization and source-order independence
- add a Windows CI job covering generated-artifact drift, the production build, and real transport parity

## Root cause

On Windows, Git could check out the Responsible Use source and generated TypeScript modules with CRLF line endings while the generator emits LF, causing `check:generated` drift and platform-dependent resource bytes. Separately, the filesystem loader preserved the unspecified order returned by `readdirSync`, while the Worker bundle used sorted filenames.

## Impact

Fresh Windows clones now use canonical generated content, and every spec-loading path derives the same deterministic calculator order.

## Validation

- `npm run check` — 48 test files and 1,281 tests passed, plus package verification
- `npm run check:clinical-release` — 39 dossiers and 4 release groups passed
- targeted generator/spec-loader regressions — 25 tests passed
- real MCP transport parity — passed
- Git attributes confirmed LF for the Responsible Use source and all five generated TypeScript artifacts

Fixes #1
Fixes #2
