### PR TITLE
feat: migrate OathMCP to MCP SDK v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run check
+      - run: npm run check:worker
 
   windows-portability:
     runs-on: windows-latest

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -36,6 +36,7 @@ jobs:
       - if: startsWith(github.ref, 'refs/tags/v')
         run: npm run check:release-metadata -- --tag "$GITHUB_REF_NAME"
       - run: npm run check:release
+      - run: npm run check:worker
 
   deploy-production:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to OathMCP are documented here.
 
 ## Unreleased
 
+- Migrated the MCP boundary to the split TypeScript SDK v2 packages and one
+  stateless dual-era implementation serving modern protocol `2026-07-28` plus
+  the supported legacy era over stdio, Node HTTP, and Cloudflare Workers.
+- Added explicit legacy/modern transport matrices, raw protocol checks, a real
+  workerd smoke, and modern-first production verification with a bounded legacy
+  smoke.
+- **Breaking for pre-1.0 embedders:** the `oath-mcp/server` export path and
+  `buildServer()` name are unchanged, but the returned `McpServer` is an SDK v2
+  object. Interoperability with SDK v1 transport objects is not retained.
 - Added one tag-driven release workflow that validates the package-version
   attestation, deploys the MCP and Blume documentation Workers from the same
   commit, verifies both production surfaces, and only then creates a GitHub

--- a/README.md
+++ b/README.md
@@ -102,6 +102,21 @@ session state is retained. A client points at the deployed streamable HTTP URL:
 }
 ```
 
+The stdio, Node HTTP, and Worker entrypoints use one MCP SDK v2 implementation
+to serve modern protocol `2026-07-28` and the supported stateless legacy era.
+Modern HTTP requests include protocol/client metadata in the message and mirror
+routing through `MCP-Protocol-Version`, `Mcp-Method`, and, when applicable,
+`Mcp-Name`. Browser preflights allow `Accept`, `Content-Type`, and those three
+MCP headers. HTTP responses use `Cache-Control: no-store`; the SDK selects JSON
+for complete non-streaming exchanges and request-scoped SSE when required,
+without creating a persistent MCP session.
+
+Around February 2027 is only the earliest review date for legacy support, not a
+protocol cutoff. Removing it requires a later announced breaking release after
+at least two successful modern OathMCP releases, support in the major documented
+clients, consistently green modern-first production verification, and advance
+deprecation notice.
+
 Run the HTTP transports locally:
 
 ```bash

--- a/docs-site/docs/reference/transport.mdx
+++ b/docs-site/docs/reference/transport.mdx
@@ -7,11 +7,28 @@ OathMCP supports stdio, stateless Streamable HTTP, and Cloudflare Workers. MCP
 SDK imports remain confined to the server boundary; calculation behavior is
 shared with the pure engine.
 
-The official Worker:
+All three entrypoints use one MCP SDK v2 implementation to serve modern protocol
+`2026-07-28` and the supported stateless legacy era. Every HTTP request receives
+a fresh MCP server; no persistent MCP session is retained.
 
-- returns JSON rather than holding an SSE stream;
+Modern HTTP messages include protocol/client metadata and mirror routing through
+`MCP-Protocol-Version`, `Mcp-Method`, and, when applicable, `Mcp-Name` headers.
+Browser preflights allow `Accept`, `Content-Type`, and those three MCP headers.
+The SDK selects JSON for complete non-streaming exchanges and request-scoped SSE
+when required; both remain request-scoped and use `Cache-Control: no-store`.
+
+The official Worker additionally:
+
 - accepts one MCP JSON-RPC message per POST and rejects JSON-RPC batches;
-- uses `Cache-Control: no-store` for MCP responses;
 - rejects request bodies over 100 KiB;
 - redirects plaintext HTTP to HTTPS and sends HSTS on HTTPS responses; and
 - applies a per-client rate limit at the public edge.
+
+Around February 2027 is only OathMCP's earliest evidence review date for legacy
+support, not a protocol cutoff. Removal requires a later announced breaking
+release after two successful modern releases, support in the major documented
+clients, consistently green modern-first production verification, and advance
+deprecation notice.
+
+Clinical and deployment responsibilities remain defined by
+[Responsible use](/responsible-use).

--- a/docs/HOSTING.md
+++ b/docs/HOSTING.md
@@ -52,12 +52,32 @@ The Worker additionally redirects plaintext HTTP to the identical HTTPS URL,
 adds `Strict-Transport-Security: max-age=31536000; includeSubDomains` to every
 HTTPS response, cancels request streams as soon as they exceed 100 KiB, and
 rejects JSON-RPC batches because Streamable HTTP carries exactly one MCP message
-per POST. MCP responses use `Cache-Control: no-store`; the stateless transport
-returns JSON rather than opening an SSE stream.
+per POST. MCP responses use `Cache-Control: no-store`.
 
 The application does not log inputs, request bodies, calculated values, patient
 data, or error payload contents. Cloudflare platform metadata may still be
 processed under the Cloudflare account and its configured observability policy.
+
+## Protocol compatibility
+
+The stdio, Node HTTP, and Worker entrypoints share one MCP SDK v2 implementation
+that serves modern protocol `2026-07-28` and the supported stateless legacy era.
+Each HTTP request creates a fresh MCP server; no MCP session or Durable Object
+holds protocol state between requests.
+
+Modern HTTP messages carry protocol version and client capability metadata;
+client identity metadata may also be present. Clients mirror routing through
+`MCP-Protocol-Version`, `Mcp-Method`, and, where applicable, `Mcp-Name`. Browser
+preflight allows `Accept`, `Content-Type`, and those three MCP headers. MCP responses retain
+`Cache-Control: no-store`. The SDK selects JSON for complete non-streaming
+exchanges and request-scoped SSE when required; neither response form changes
+the service's stateless ownership model.
+
+Around February 2027 is the earliest evidence review date for legacy support,
+not a scheduled protocol cutoff. Legacy removal requires a later announced
+breaking release, at least two successful modern OathMCP releases, support in
+the major documented clients, consistently green modern-first production
+verification, and advance deprecation notice.
 
 ## Tagged production deployment
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -98,14 +98,19 @@ Before merging, also:
   Blume surface, the package manifest, `LICENSE`, and `NOTICE`;
 - run `npm audit --omit=dev` for the published runtime and separately review the
   development dependency findings used by deployment and documentation builds;
-  and
-- re-review the documented `docs-site` dependency waiver whenever its framework
-  graph or enabled features change.
+- inspect the root `npm ls` graph and package manifest: the split MCP SDK v2
+  server, Node, and Express packages must be runtime dependencies, the v2 client
+  must remain development-only, and neither the monolithic v1 SDK nor a Hono
+  override may be present;
+- review the isolated MCP SDK v1 copy pulled into `docs-site` by Blume, confirm
+  no root runtime, test, or release script imports it, and re-review that waiver
+  whenever Blume's dependency graph or enabled features change; and
+- confirm the comprehensive production verifier pins modern protocol
+  `2026-07-28` and its separate bounded legacy list/resource/calculation smoke
+  remains green.
 
-The MCP SDK currently relies on the checked-in `@hono/node-server` override;
-real transport parity is the compatibility gate until the SDK adopts that major
-version directly. Do not override Miniflare's exact Sharp pin; adopt Sharp
-updates through a compatible Wrangler release.
+Do not override Miniflare's exact Sharp pin; adopt Sharp updates through a
+compatible Wrangler release.
 
 ## Tag the verified release commit
 
@@ -136,12 +141,15 @@ publisher. A `v*` tag runs these ordered jobs:
 3. Deploy `oath-mcp` and then the tagged Blume `oath-docs` Worker under one
    protected-environment approval.
 4. Poll the live service until `/health` reports the tagged version.
-5. Compare every live `calc://<id>/evidence` resource with the attested catalog.
+5. Open a modern-pinned `2026-07-28` client and compare every live
+   `calc://<id>/evidence` resource with the attested catalog.
 6. Call `describe_calculator` for every calculator and calculate a source-linked
    reference case for every calculator newly added since the prior attestation.
-7. Fetch and verify one generated Blume page for every attested calculator.
-8. Optionally publish the npm package through trusted publishing.
-9. Attach the package tarball and both Cloudflare Worker version IDs to the
+7. Open a separate explicit-legacy client and require the bounded
+   list/resource/calculation smoke to pass.
+8. Fetch and verify one generated Blume page for every attested calculator.
+9. Optionally publish the npm package through trusted publishing.
+10. Attach the package tarball and both Cloudflare Worker version IDs to the
    GitHub release.
 
 Any failure prevents the GitHub release. Do not announce a calculator from a

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/express": "^2.0.0",
+        "@modelcontextprotocol/node": "^2.0.0",
+        "@modelcontextprotocol/server": "^2.0.0",
         "express": "^4",
         "yaml": "^2.9.0",
         "zod": "^4.4.0"
@@ -18,6 +20,7 @@
         "oath-mcp": "dist/server/stdio.js"
       },
       "devDependencies": {
+        "@modelcontextprotocol/client": "^2.0.0",
         "@types/express": "^4.17.21",
         "@types/node": "^22",
         "fast-check": "^4.9.0",
@@ -607,18 +610,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@hono/node-server": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
-      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
-    },
     "node_modules/@img/colour": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
@@ -1137,359 +1128,97 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
+        "@modelcontextprotocol/core": "2.0.0",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
         "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
+        "zod": "^4.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/express": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/express/-/express-2.0.0.tgz",
+      "integrity": "sha512-Snlr8j9FR9LcVvEJPF7qJ7d5zTL4Bes2dk7RcacN9eSZ7OLohwxqhEvWu1+UxELyScgLbLLOdeVEGdwKI1iwVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cors": "^2.8.5"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
+        "@modelcontextprotocol/server": "^2.0.0",
+        "express": "^4.18.0 || ^5.0.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
+      "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/server": "^2.0.0",
+        "hono": "^4.11.4"
       },
       "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
-        }
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
-      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^2.0.0",
-        "debug": "^4.4.3",
-        "http-errors": "^2.0.1",
-        "iconv-lite": "^0.7.2",
-        "on-finished": "^2.4.1",
-        "qs": "^6.15.2",
-        "raw-body": "^3.0.2",
-        "type-is": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
-      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.6.0"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
+        "hono": {
           "optional": true
         }
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+    "node_modules/@modelcontextprotocol/node/node_modules/@hono/node-server": {
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "license": "MIT",
-      "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.1",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
-      },
       "engines": {
-        "node": ">= 18"
+        "node": ">=18.14.1"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
-      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+    "node_modules/@modelcontextprotocol/server": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
-      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
       },
       "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.1",
-        "mime-types": "^3.0.2",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
-      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
-      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
-      "license": "MIT",
-      "dependencies": {
-        "content-type": "^2.0.0",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+        "node": ">=20"
       }
     },
     "node_modules/@poppinss/colors": {
@@ -2162,39 +1891,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -2389,6 +2085,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2594,6 +2291,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.1"
@@ -2606,6 +2304,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
       "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -2667,24 +2366,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.2.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
-      }
-    },
     "node_modules/fast-check": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
@@ -2707,28 +2388,6 @@
       "engines": {
         "node": ">=12.17.0"
       }
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2886,6 +2545,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
       "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2928,15 +2588,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -2946,22 +2597,18 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/jose": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
       "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -2973,18 +2620,6 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/kleur": {
       "version": "4.1.5",
@@ -3170,15 +2805,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -3192,6 +2818,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3244,6 +2871,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
@@ -3333,46 +2961,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/raw-body": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
-      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.7.0",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
-      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rollup": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
@@ -3416,55 +3004,6 @@
         "@rollup/rollup-win32-x64-gnu": "4.62.2",
         "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/router": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "is-promise": "^4.0.0",
-        "parseurl": "^1.3.3",
-        "path-to-regexp": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/router/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/router/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/safe-buffer": {
@@ -3606,6 +3145,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3618,6 +3158,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4164,6 +3705,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -4256,12 +3798,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
-    },
     "node_modules/ws": {
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
@@ -4345,15 +3881,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   "files": [
     "dist",
     "!dist/cli",
+    "!dist/server/in-memory-client.*",
+    "!dist/server/compatibility.*",
+    "!dist/server/validation-case-runner.*",
     "specs",
     "validation",
     "templates",
@@ -76,12 +79,15 @@
     "deploy:worker": "npm run check:deploy && wrangler deploy"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/express": "^2.0.0",
+    "@modelcontextprotocol/node": "^2.0.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "express": "^4",
     "yaml": "^2.9.0",
     "zod": "^4.4.0"
   },
   "devDependencies": {
+    "@modelcontextprotocol/client": "^2.0.0",
     "@types/express": "^4.17.21",
     "@types/node": "^22",
     "fast-check": "^4.9.0",
@@ -89,8 +95,5 @@
     "typescript": "^5",
     "vitest": "^3",
     "wrangler": "^4.113.0"
-  },
-  "overrides": {
-    "@hono/node-server": "2.0.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "start:stdio": "node dist/server/stdio.js",
     "start:http": "node dist/server/http.js",
     "types:worker": "wrangler types src/server/worker-configuration.d.ts --strict-vars false",
-    "check:worker": "npm run build && wrangler types src/server/worker-configuration.d.ts --strict-vars false --check && wrangler deploy --dry-run",
+    "check:worker": "npm run build && wrangler types src/server/worker-configuration.d.ts --strict-vars false --check && node scripts/check-worker-bundle.mjs",
     "check:deploy": "npm run check:release && wrangler types src/server/worker-configuration.d.ts --strict-vars false --check && wrangler deploy --dry-run",
     "deploy:worker": "npm run check:deploy && wrangler deploy"
   },

--- a/scripts/check-worker-bundle.d.mts
+++ b/scripts/check-worker-bundle.d.mts
@@ -1,0 +1,18 @@
+export interface BundleSize {
+  bytes: number;
+  unit: string;
+  value: number;
+}
+
+export interface WranglerDryRunResult {
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+}
+
+export function parseGzipSize(...outputs: string[]): BundleSize;
+export function assertBelowFreeLimit(size: BundleSize): void;
+export function checkWorkerBundle(options?: {
+  log?: (message: string) => void;
+  runWrangler?: () => Promise<WranglerDryRunResult>;
+}): Promise<number>;

--- a/scripts/check-worker-bundle.mjs
+++ b/scripts/check-worker-bundle.mjs
@@ -1,0 +1,92 @@
+import { spawn } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const FREE_LIMIT_BYTES = 3 * 1024 ** 2;
+
+export function parseGzipSize(...outputs) {
+  const match = outputs
+    .map((output) => output.match(
+      /Total Upload[^\r\n]*\/\s*gzip:\s*([\d.]+)\s*(KiB|MiB)/i,
+    ))
+    .find((candidate) => candidate !== null);
+  if (!match) {
+    throw new Error('Wrangler output did not report a gzip bundle size');
+  }
+
+  const value = Number(match[1]);
+  const unit = match[2];
+  const bytes = value * (unit.toLowerCase() === 'mib' ? 1024 ** 2 : 1024);
+  if (!Number.isFinite(bytes)) {
+    throw new Error(`Wrangler reported an invalid gzip bundle size: ${match[1]} ${unit}`);
+  }
+  return { bytes, unit, value };
+}
+
+export function assertBelowFreeLimit(size) {
+  if (size.bytes >= FREE_LIMIT_BYTES) {
+    throw new Error(
+      `Worker gzip bundle must remain below 3 MiB; received ${size.value} ${size.unit}`,
+    );
+  }
+}
+
+function runWranglerDryRun({
+  npmExecPath = process.env.npm_execpath,
+  spawnImpl = spawn,
+  stderr = process.stderr,
+  stdout = process.stdout,
+} = {}) {
+  if (!npmExecPath) {
+    throw new Error('npm_execpath is required; run this check through npm');
+  }
+
+  const child = spawnImpl(
+    process.execPath,
+    [npmExecPath, 'exec', '--', 'wrangler', 'deploy', '--dry-run'],
+    { env: process.env, stdio: ['inherit', 'pipe', 'pipe'] },
+  );
+  let stderrOutput = '';
+  let stdoutOutput = '';
+
+  child.stdout.on('data', (chunk) => {
+    const text = chunk.toString();
+    stdoutOutput += text;
+    stdout.write(text);
+  });
+  child.stderr.on('data', (chunk) => {
+    const text = chunk.toString();
+    stderrOutput += text;
+    stderr.write(text);
+  });
+
+  return new Promise((resolve, reject) => {
+    child.once('error', reject);
+    child.once('close', (code, signal) => {
+      if (signal !== null) {
+        reject(new Error(`Wrangler dry run terminated by ${signal}`));
+        return;
+      }
+      resolve({ exitCode: code ?? 1, stderr: stderrOutput, stdout: stdoutOutput });
+    });
+  });
+}
+
+export async function checkWorkerBundle({
+  log = console.log,
+  runWrangler = runWranglerDryRun,
+} = {}) {
+  const result = await runWrangler();
+  if (result.exitCode !== 0) {
+    return result.exitCode;
+  }
+
+  const size = parseGzipSize(result.stdout, result.stderr);
+  assertBelowFreeLimit(size);
+  log(`Worker gzip bundle: ${size.value} ${size.unit} (limit: < 3 MiB)`);
+  return 0;
+}
+
+const entryPath = process.argv[1];
+if (entryPath !== undefined && pathToFileURL(entryPath).href === import.meta.url) {
+  process.exitCode = await checkWorkerBundle();
+}

--- a/scripts/release/verify-production.d.mts
+++ b/scripts/release/verify-production.d.mts
@@ -1,0 +1,12 @@
+export interface McpReleaseContract {
+  version: string;
+  attestation: {
+    calculatorIds: readonly string[];
+  };
+  newCalculatorIds: readonly string[];
+}
+
+export function verifyMcpSurface(
+  baseUrl: string | URL,
+  release: McpReleaseContract,
+): Promise<void>;

--- a/scripts/release/verify-production.mjs
+++ b/scripts/release/verify-production.mjs
@@ -1,9 +1,11 @@
 import { readdir, readFile } from "node:fs/promises";
 import { resolve, relative, sep } from "node:path";
+import { pathToFileURL } from "node:url";
 import { Client, StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
 import YAML from "yaml";
 
 const root = resolve(import.meta.dirname, "../..");
+const MODERN_PROTOCOL_VERSION = "2026-07-28";
 
 function parseArgs(argv) {
   const options = {
@@ -102,6 +104,25 @@ async function listAllResources(client) {
   return resources;
 }
 
+async function expectedPromptNames(calculatorIds) {
+  const specs = await Promise.all(calculatorIds.map(async (id) => YAML.parse(
+    await readFile(resolve(root, "specs", `${id}.yaml`), "utf8"),
+  )));
+  return specs
+    .filter((spec) => spec.prompt !== undefined)
+    .map((spec) => `interpret_${spec.id}`)
+    .sort();
+}
+
+function requireExactCatalog(label, actual, expected) {
+  const actualSorted = [...actual].sort();
+  const expectedSorted = [...expected].sort();
+  if (JSON.stringify(actualSorted) === JSON.stringify(expectedSorted)) return;
+  const missing = expectedSorted.filter((value) => !actualSorted.includes(value));
+  const extra = actualSorted.filter((value) => !expectedSorted.includes(value));
+  throw new Error(`Production ${label} mismatch; missing=${missing.join(",")}; extra=${extra.join(",")}`);
+}
+
 async function calculateNewEntries(client, calculatorIds) {
   for (const id of calculatorIds) {
     const dossier = YAML.parse(
@@ -118,6 +139,91 @@ async function calculateNewEntries(client, calculatorIds) {
     if (result.isError === true) {
       throw new Error(`Production calculation failed for new calculator ${id} using ${testCase.id}`);
     }
+    if (result.structuredContent?.result?.calculator !== id || result.structuredContent.result.ok !== true) {
+      throw new Error(`Production calculation identity differs for new calculator ${id}`);
+    }
+  }
+}
+
+export async function verifyMcpSurface(baseUrl, release) {
+  const modernClient = new Client(
+    { name: "oathmcp-release-verifier-modern", version: release.version },
+    { versionNegotiation: { mode: { pin: MODERN_PROTOCOL_VERSION } } },
+  );
+  try {
+    await modernClient.connect(new StreamableHTTPClientTransport(new URL("/mcp", baseUrl)));
+    if (modernClient.getProtocolEra() !== "modern") {
+      throw new Error("Production MCP verification did not negotiate the modern protocol era");
+    }
+    const expectedIds = [...release.attestation.calculatorIds].sort();
+    const [{ tools }, { prompts }, resources, expectedPrompts] = await Promise.all([
+      modernClient.listTools(),
+      modernClient.listPrompts(),
+      listAllResources(modernClient),
+      expectedPromptNames(expectedIds),
+    ]);
+    const toolNames = tools.map((tool) => tool.name).sort();
+    const expectedTools = ["calculate", "calculate_panel", "describe_calculator", "find_calculator"];
+    requireExactCatalog("compact tool catalog", toolNames, expectedTools);
+    requireExactCatalog(
+      "prompt catalog",
+      prompts.map((prompt) => prompt.name),
+      expectedPrompts,
+    );
+    requireExactCatalog(
+      "resource catalog",
+      resources.map((resource) => resource.uri),
+      [...expectedIds.map((id) => `calc://${id}/evidence`), "oath://responsible-use"],
+    );
+
+    for (const id of expectedIds) {
+      const uri = `calc://${id}/evidence`;
+      const [evidence, result] = await Promise.all([
+        modernClient.readResource({ uri }),
+        modernClient.callTool({
+          name: "describe_calculator",
+          arguments: { id },
+        }),
+      ]);
+      if (!evidence.contents.some(
+        (content) => content.uri === uri && "text" in content && content.text.length > 0,
+      )) {
+        throw new Error(`Production evidence response differs for ${id}`);
+      }
+      if (result.isError === true) throw new Error(`Production cannot describe ${id}`);
+      if (result.structuredContent?.calculator?.id !== id) {
+        throw new Error(`Production descriptor identity differs for ${id}`);
+      }
+    }
+    await modernClient.readResource({ uri: "oath://responsible-use" });
+    await calculateNewEntries(modernClient, release.newCalculatorIds);
+  } finally {
+    await modernClient.close();
+  }
+
+  const legacyClient = new Client(
+    { name: "oathmcp-release-verifier-legacy", version: release.version },
+    { versionNegotiation: { mode: "legacy" } },
+  );
+  try {
+    await legacyClient.connect(new StreamableHTTPClientTransport(new URL("/mcp", baseUrl)));
+    if (legacyClient.getProtocolEra() !== "legacy") {
+      throw new Error("Production MCP compatibility smoke did not negotiate the legacy era");
+    }
+    const { tools } = await legacyClient.listTools();
+    if (!tools.some((tool) => tool.name === "calculate")) {
+      throw new Error("Production legacy compatibility smoke is missing calculate");
+    }
+    await legacyClient.readResource({ uri: "oath://responsible-use" });
+    const calculation = await legacyClient.callTool({
+      name: "calculate",
+      arguments: { id: "bmi", inputs: { weight_kg: 70, height_cm: 170 } },
+    });
+    if (calculation.isError === true) {
+      throw new Error("Production legacy compatibility BMI smoke failed");
+    }
+  } finally {
+    await legacyClient.close();
   }
 }
 
@@ -129,45 +235,7 @@ async function verifyOnce(baseUrl, release) {
     throw new Error(`Production reports ${health.version}; expected ${release.version}`);
   }
 
-  const client = new Client({ name: "oathmcp-release-verifier", version: release.version });
-  const transport = new StreamableHTTPClientTransport(new URL("/mcp", baseUrl));
-  await client.connect(transport);
-  try {
-    const [{ tools }, resources] = await Promise.all([
-      client.listTools(),
-      listAllResources(client),
-    ]);
-    const toolNames = tools.map((tool) => tool.name).sort();
-    const expectedTools = ["calculate", "calculate_panel", "describe_calculator", "find_calculator"];
-    if (JSON.stringify(toolNames) !== JSON.stringify(expectedTools)) {
-      throw new Error(`Production compact tools differ: ${toolNames.join(", ")}`);
-    }
-
-    const expectedIds = [...release.attestation.calculatorIds].sort();
-    const resourceIds = resources
-      .map((resource) => /^calc:\/\/([^/]+)\/evidence$/u.exec(resource.uri)?.[1])
-      .filter(Boolean)
-      .sort();
-    if (JSON.stringify(resourceIds) !== JSON.stringify(expectedIds)) {
-      const missing = expectedIds.filter((id) => !resourceIds.includes(id));
-      const extra = resourceIds.filter((id) => !expectedIds.includes(id));
-      throw new Error(`Production catalog mismatch; missing=${missing.join(",")}; extra=${extra.join(",")}`);
-    }
-    if (!resources.some((resource) => resource.uri === "oath://responsible-use")) {
-      throw new Error("Production is missing oath://responsible-use");
-    }
-
-    for (const id of expectedIds) {
-      const result = await client.callTool({
-        name: "describe_calculator",
-        arguments: { id },
-      });
-      if (result.isError === true) throw new Error(`Production cannot describe ${id}`);
-    }
-    await calculateNewEntries(client, release.newCalculatorIds);
-  } finally {
-    await client.close();
-  }
+  await verifyMcpSurface(baseUrl, release);
 
   const docsPaths = await calculatorDocsPaths(release.attestation.calculatorIds);
   for (const [id, path] of docsPaths) {
@@ -183,26 +251,35 @@ async function verifyOnce(baseUrl, release) {
   if (!responsibleUse.ok) throw new Error(`Responsible Use returned HTTP ${responsibleUse.status}`);
 }
 
-const options = parseArgs(process.argv.slice(2));
-const release = await loadRelease();
-const startedAt = Date.now();
-let lastError;
-do {
-  try {
-    await verifyOnce(options.baseUrl, release);
-    console.log(
-      `Production verification passed: ${release.version}; ` +
-      `${release.attestation.calculatorIds.length} MCP calculators; ` +
-      `${release.attestation.calculatorIds.length} Blume pages; ` +
-      `${release.newCalculatorIds.length} newly published calculators exercised.`,
-    );
-    process.exit(0);
-  } catch (error) {
-    lastError = error;
-    if (Date.now() - startedAt >= options.timeoutMs) break;
-    console.log(`Production not ready: ${error instanceof Error ? error.message : String(error)}; retrying.`);
-    await new Promise((resolvePromise) => setTimeout(resolvePromise, 5_000));
-  }
-} while (true);
+async function runCli() {
+  const options = parseArgs(process.argv.slice(2));
+  const release = await loadRelease();
+  const startedAt = Date.now();
+  let lastError;
+  do {
+    try {
+      await verifyOnce(options.baseUrl, release);
+      console.log(
+        `Production verification passed: ${release.version}; ` +
+        `${release.attestation.calculatorIds.length} MCP calculators; ` +
+        `${release.attestation.calculatorIds.length} Blume pages; ` +
+        `${release.newCalculatorIds.length} newly published calculators exercised.`,
+      );
+      return;
+    } catch (error) {
+      lastError = error;
+      if (Date.now() - startedAt >= options.timeoutMs) break;
+      console.log(`Production not ready: ${error instanceof Error ? error.message : String(error)}; retrying.`);
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 5_000));
+    }
+  } while (true);
 
-throw lastError;
+  throw lastError;
+}
+
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  await runCli();
+}

--- a/scripts/release/verify-production.mjs
+++ b/scripts/release/verify-production.mjs
@@ -1,7 +1,6 @@
 import { readdir, readFile } from "node:fs/promises";
 import { resolve, relative, sep } from "node:path";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { Client, StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
 import YAML from "yaml";
 
 const root = resolve(import.meta.dirname, "../..");

--- a/src/server/build-tools.ts
+++ b/src/server/build-tools.ts
@@ -9,8 +9,7 @@
  * constrained to the spec's declared outputs.
  */
 import { createRequire } from 'node:module';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { completable } from '@modelcontextprotocol/sdk/server/completable.js';
+import { McpServer, completable } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import { fillTemplate as fillPromptTemplate } from '../engine/prompt-template.js';
 import {
@@ -112,9 +111,7 @@ function promptStringSchema(input: InputSpec): z.ZodType<string> {
 function promptArgsShape(spec: CalcSpec): Record<string, z.ZodType> {
   return Object.fromEntries(
     Object.entries(spec.inputs).map(([name, input]) => {
-      let field: z.ZodType = promptStringSchema(input);
-      if (!input.required) field = field.optional();
-      field = field.describe(promptArgDescription(input));
+      let field: z.ZodType = promptStringSchema(input).describe(promptArgDescription(input));
       if (input.kind === 'boolean' || input.kind === 'enum') {
         const choices = input.kind === 'boolean'
           ? ['true', 'false']
@@ -124,6 +121,7 @@ function promptArgsShape(spec: CalcSpec): Record<string, z.ZodType> {
           return choices.filter((choice) => choice.toLowerCase().startsWith(prefix));
         });
       }
+      if (!input.required) field = field.optional();
       return [name, field];
     }),
   );
@@ -145,7 +143,7 @@ function fillTemplate(template: string, result: ReturnType<typeof run>): string 
 
 interface PromptDefinition {
   name: string;
-  config: { title: string; description: string; argsSchema: Record<string, z.ZodType> };
+  config: { title: string; description: string; argsSchema: z.ZodObject };
   // The SDK infers the arg values as `unknown` from the wide raw-shape type; each
   // is a validated string (or absent) at runtime — narrowed in the handler.
   handler: (args: Record<string, unknown>) => {
@@ -169,7 +167,7 @@ function buildPromptDefinition(spec: CalcSpec): PromptDefinition {
     config: {
       title: `Interpret ${spec.name}`,
       description: prompt.description,
-      argsSchema: promptArgsShape(spec),
+      argsSchema: z.object(promptArgsShape(spec)),
     },
     handler: (args) => {
       const rawInputs: Record<string, unknown> = {};
@@ -666,7 +664,7 @@ export function buildServer(options: BuildServerOptions = {}): McpServer {
   // Materialize specs only when the shared cache is cold. On the warm
   // stateless-HTTP path, spec validation and derived contract work are skipped.
   if (sharedCatalogDefinitions === null) {
-    const specs = [...loadSpecs().values()];
+    const specs = [...loadSpecs().values()].sort((left, right) => left.id.localeCompare(right.id));
     assertComputeCoverage(
       specs.map((spec) => spec.id),
       getRegisteredComputeIds(),

--- a/src/server/catalog-contract.test.ts
+++ b/src/server/catalog-contract.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { ProtocolError, ProtocolErrorCode } from '@modelcontextprotocol/client';
 import { convert, loadSpec } from '../engine/index.js';
 import type { InputSpec } from '../engine/index.js';
 import { connectTestClient } from '../../test/support/mcp-client.js';
@@ -48,9 +49,9 @@ const CALCULATOR_IDS = [
 ] as const;
 
 const DISPATCH_TOOLS = [
-  'calculate_panel',
-  'describe_calculator',
   'find_calculator',
+  'describe_calculator',
+  'calculate_panel',
 ] as const;
 const PROMPT_IDS = ['abg', 'csf', 'hepb'] as const;
 
@@ -76,6 +77,18 @@ function promptArgument(input: InputSpec, raw: unknown): string {
   return String(raw);
 }
 
+async function expectInvalidPromptArguments(operation: Promise<unknown>): Promise<void> {
+  let caught: unknown;
+  try {
+    await operation;
+  } catch (error) {
+    caught = error;
+  }
+  expect(caught).toBeInstanceOf(ProtocolError);
+  expect(caught).toMatchObject({ code: ProtocolErrorCode.InvalidParams });
+  expect((caught as Error).message).toMatch(/Invalid (?:params|arguments)/i);
+}
+
 describe('MCP catalog contract', () => {
   it('publishes concise clinical-use instructions at initialization', async () => {
     const client = await connectTestClient('catalog-instructions-test');
@@ -93,23 +106,26 @@ describe('MCP catalog contract', () => {
       client.listPrompts(),
       client.listResources(),
     ]);
+    const [{ tools: repeatedTools }, { prompts: repeatedPrompts }, { resources: repeatedResources }] =
+      await Promise.all([
+        client.listTools(),
+        client.listPrompts(),
+        client.listResources(),
+      ]);
 
     expect(tools).toHaveLength(43);
     expect(prompts).toHaveLength(3);
     expect(resources).toHaveLength(41);
 
-    expect(tools.map((tool) => tool.name).sort()).toEqual(
-      [
-        ...CALCULATOR_IDS.map((id) => `calculate_${id}`),
-        ...DISPATCH_TOOLS,
-      ].sort(),
-    );
-    expect(prompts.map((prompt) => prompt.name).sort()).toEqual(
-      PROMPT_IDS.map((id) => `interpret_${id}`).sort(),
-    );
-    expect(resources.map((resource) => resource.uri).sort()).toEqual(
-      [...CALCULATOR_IDS.map((id) => `calc://${id}/evidence`), 'oath://responsible-use'].sort(),
-    );
+    const toolNames = [...CALCULATOR_IDS.map((id) => `calculate_${id}`), ...DISPATCH_TOOLS];
+    const promptNames = PROMPT_IDS.map((id) => `interpret_${id}`);
+    const resourceUris = [...CALCULATOR_IDS.map((id) => `calc://${id}/evidence`), 'oath://responsible-use'];
+    expect(tools.map((tool) => tool.name)).toEqual(toolNames);
+    expect(prompts.map((prompt) => prompt.name)).toEqual(promptNames);
+    expect(resources.map((resource) => resource.uri)).toEqual(resourceUris);
+    expect(repeatedTools.map((tool) => tool.name)).toEqual(toolNames);
+    expect(repeatedPrompts.map((prompt) => prompt.name)).toEqual(promptNames);
+    expect(repeatedResources.map((resource) => resource.uri)).toEqual(resourceUris);
 
     for (const tool of tools) {
       expect(tool.inputSchema.type, tool.name).toBe('object');
@@ -259,28 +275,28 @@ describe('MCP catalog contract', () => {
 
   it('rejects blank/bad prompt values as invalid params and completes closed choices', async () => {
     const client = await connectTestClient('catalog-prompt-validation-test');
-    await expect(client.getPrompt({
+    await expectInvalidPromptArguments(client.getPrompt({
       name: 'interpret_abg',
       arguments: {
         ph: ' ', paco2: '40', bicarbonate: '24', sodium: '140', chloride: '104',
       },
-    })).rejects.toThrow(/-32602|Invalid params/i);
-    await expect(client.getPrompt({
+    }));
+    await expectInvalidPromptArguments(client.getPrompt({
       name: 'interpret_abg',
       arguments: {
         ph: 'not-a-number', paco2: '40', bicarbonate: '24', sodium: '140', chloride: '104',
       },
-    })).rejects.toThrow(/-32602|Invalid params/i);
-    await expect(client.getPrompt({
+    }));
+    await expectInvalidPromptArguments(client.getPrompt({
       name: 'interpret_abg',
       arguments: {
         ph: '7.4', paco2: '40', bicarbonate: '24', sodium: '140', chloride: '104', venous_sample: 'maybe',
       },
-    })).rejects.toThrow(/-32602|Invalid params/i);
-    await expect(client.getPrompt({
+    }));
+    await expectInvalidPromptArguments(client.getPrompt({
       name: 'interpret_hepb',
       arguments: { hbsag: 'maybe', anti_hbc_total: 'negative', anti_hbs: 'negative' },
-    })).rejects.toThrow(/-32602|Invalid params/i);
+    }));
 
     const completion = await client.complete({
       ref: { type: 'ref/prompt', name: 'interpret_abg' },

--- a/src/server/http.test.ts
+++ b/src/server/http.test.ts
@@ -1,8 +1,9 @@
 import http, { type Server } from 'node:http';
 import { once } from 'node:events';
-import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
 import { afterEach, describe, expect, it } from 'vitest';
 import { startLoopbackHttp } from '../../test/support/transport-harness.js';
+
+const LEGACY_PROTOCOL_VERSION = '2025-11-25';
 
 const servers: Server[] = [];
 
@@ -24,7 +25,7 @@ const initializeBody = JSON.stringify({
   id: 1,
   method: 'initialize',
   params: {
-    protocolVersion: LATEST_PROTOCOL_VERSION,
+    protocolVersion: LEGACY_PROTOCOL_VERSION,
     capabilities: {},
     clientInfo: { name: 'http-test', version: '0.0.0' },
   },

--- a/src/server/http.test.ts
+++ b/src/server/http.test.ts
@@ -1,22 +1,31 @@
-import http, { type Server } from 'node:http';
-import { once } from 'node:events';
+import http from 'node:http';
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import { afterEach, describe, expect, it } from 'vitest';
-import { startLoopbackHttp } from '../../test/support/transport-harness.js';
+import {
+  startLoopbackHttp,
+  type LoopbackHttpServer,
+} from '../../test/support/transport-harness.js';
+import {
+  LEGACY_PROTOCOL_VERSION,
+  MODERN_PROTOCOL_VERSION,
+} from '../../test/support/protocol-fixtures.js';
+import { startHttpServer } from './http.js';
 
-const LEGACY_PROTOCOL_VERSION = '2025-11-25';
-
-const servers: Server[] = [];
+const servers: LoopbackHttpServer[] = [];
 
 afterEach(async () => {
-  await Promise.allSettled(servers.splice(0).map(async (server) => {
-    server.close();
-    await once(server, 'close');
-  }));
+  const results = await Promise.allSettled(
+    servers.splice(0).map((server) => server.close()),
+  );
+  const failures = results.flatMap((result) => result.status === 'rejected' ? [result.reason] : []);
+  if (failures.length > 0) {
+    throw new AggregateError(failures, 'Failed to close Node HTTP test servers.');
+  }
 });
 
 async function start(allowedOrigins = new Set<string>()): Promise<string> {
   const connection = await startLoopbackHttp({ allowedOrigins });
-  servers.push(connection.server);
+  servers.push(connection);
   return connection.url.origin;
 }
 
@@ -50,8 +59,10 @@ describe('Node Streamable HTTP transport', () => {
     const allowed = await fetch(`${url}/mcp`, initializeRequest('https://app.example'));
     expect(noOrigin.status).toBe(200);
     expect(allowed.status).toBe(200);
-    expect(noOrigin.headers.get('content-type')).toBe('application/json');
-    expect(allowed.headers.get('content-type')).toBe('application/json');
+    expect(['application/json', 'text/event-stream'])
+      .toContain(noOrigin.headers.get('content-type'));
+    expect(['application/json', 'text/event-stream'])
+      .toContain(allowed.headers.get('content-type'));
     expect(noOrigin.headers.get('cache-control')).toBe('no-store');
     expect(noOrigin.headers.get('x-content-type-options')).toBe('nosniff');
     expect(allowed.headers.get('access-control-allow-origin')).toBe('https://app.example');
@@ -63,6 +74,33 @@ describe('Node Streamable HTTP transport', () => {
     expect(preflight.status).toBe(204);
     expect(preflight.headers.get('access-control-allow-origin')).toBe('https://app.example');
     expect(preflight.headers.get('access-control-allow-methods')).toContain('POST');
+    expect(preflight.headers.get('access-control-allow-headers')?.toLowerCase())
+      .toBe('accept, content-type, mcp-protocol-version, mcp-method, mcp-name');
+  });
+
+  it('serves a modern discovery and tools list through the shared handler', async () => {
+    const url = await start();
+    const client = new Client(
+      { name: 'http-modern-smoke', version: '0.0.0' },
+      { versionNegotiation: { mode: { pin: MODERN_PROTOCOL_VERSION } } },
+    );
+    try {
+      await client.connect(new StreamableHTTPClientTransport(new URL(`${url}/mcp`)));
+      expect(client.getProtocolEra()).toBe('modern');
+      expect(client.getDiscoverResult()).toBeDefined();
+      const { tools } = await client.listTools();
+      expect(tools.map(({ name }) => name)).toContain('calculate_bmi');
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('closes the HTTP owner idempotently before an asynchronous bind completes', async () => {
+    const running = startHttpServer({ port: 0, host: '127.0.0.1' });
+    await Promise.all([running.close(), running.close()]);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(running.server.listening).toBe(false);
+    expect(running.server.address()).toBeNull();
   });
 
   it('rejects a hostile Origin before parsing a malformed body', async () => {

--- a/src/server/http.test.ts
+++ b/src/server/http.test.ts
@@ -8,6 +8,10 @@ import {
 import {
   LEGACY_PROTOCOL_VERSION,
   MODERN_PROTOCOL_VERSION,
+  exchangeJsonRpc,
+  jsonRpcResult,
+  modernJsonRpcRequest,
+  modernRequestHeaders,
 } from '../../test/support/protocol-fixtures.js';
 import { startHttpServer } from './http.js';
 
@@ -52,6 +56,14 @@ function initializeRequest(origin?: string): RequestInit {
   };
 }
 
+function postRaw(
+  origin: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+) {
+  return exchangeJsonRpc(body, (init) => fetch(`${origin}/mcp`, init), headers);
+}
+
 describe('Node Streamable HTTP transport', () => {
   it('accepts non-browser requests and an explicitly allowed exact Origin', async () => {
     const url = await start(new Set(['https://app.example']));
@@ -93,6 +105,86 @@ describe('Node Streamable HTTP transport', () => {
     } finally {
       await client.close();
     }
+  });
+
+  it('keeps raw legacy responses free of modern wire and session fields', async () => {
+    const url = await start();
+    const initialized = await postRaw(url, JSON.parse(initializeBody));
+    expect(initialized.response.status).toBe(200);
+    expect(initialized.response.headers.get('mcp-session-id')).toBeNull();
+    expect(jsonRpcResult(initialized.message).protocolVersion).toBe(LEGACY_PROTOCOL_VERSION);
+
+    const listed = await postRaw(url, {
+      jsonrpc: '2.0', id: 2, method: 'tools/list', params: {},
+    }, { 'MCP-Protocol-Version': LEGACY_PROTOCOL_VERSION });
+    const result = jsonRpcResult(listed.message);
+    expect(listed.response.status).toBe(200);
+    expect(listed.response.headers.get('mcp-session-id')).toBeNull();
+    expect(result).not.toHaveProperty('resultType');
+    expect(result).not.toHaveProperty('ttlMs');
+    expect(result).not.toHaveProperty('cacheScope');
+    expect(result).not.toHaveProperty('_meta');
+  });
+
+  it('serves raw modern discovery, schemas, and a complete BMI call', async () => {
+    const url = await start();
+    const modernPost = (
+      method: string,
+      params: Record<string, unknown>,
+      id: number,
+      name?: string,
+    ) => postRaw(
+      url,
+      modernJsonRpcRequest(method, params, { id, clientName: 'raw-http-modern' }),
+      modernRequestHeaders(method, name),
+    );
+
+    const discovered = await modernPost('server/discover', {}, 1);
+    expect(discovered.response.status).toBe(200);
+    expect(discovered.response.headers.get('mcp-session-id')).toBeNull();
+    expect(jsonRpcResult(discovered.message)).toMatchObject({
+      resultType: 'complete',
+      ttlMs: 0,
+      cacheScope: 'private',
+      supportedVersions: expect.arrayContaining([MODERN_PROTOCOL_VERSION]),
+    });
+
+    const listed = await modernPost('tools/list', {}, 2);
+    const listResult = jsonRpcResult(listed.message);
+    expect(listed.response.headers.get('mcp-session-id')).toBeNull();
+    expect(listResult).toMatchObject({
+      resultType: 'complete', ttlMs: 0, cacheScope: 'private',
+    });
+    const bmi = (listResult.tools as Record<string, unknown>[])
+      .find((tool) => tool.name === 'calculate_bmi');
+    expect(bmi).toBeDefined();
+    const input = bmi?.inputSchema as {
+      additionalProperties?: boolean;
+      properties?: Record<string, { description?: string }>;
+      allOf?: { anyOf?: { required?: string[] }[] }[];
+    };
+    const output = bmi?.outputSchema as { properties?: Record<string, unknown> };
+    expect(input.additionalProperties).toBe(false);
+    expect(input.properties?.weight_kg?.description).toBe('Body weight in kilograms.');
+    expect(input.properties?.weight?.description)
+      .toBe('Compatibility alias for weight_kg. Prefer weight_kg.');
+    expect(input.allOf?.[0]?.anyOf).toEqual(expect.arrayContaining([
+      { required: ['weight'] },
+      { required: ['weight_kg'] },
+    ]));
+    expect(output.properties).toHaveProperty('results');
+    expect(output.properties).toHaveProperty('evidenceUri');
+
+    const called = await modernPost('tools/call', {
+      name: 'calculate_bmi',
+      arguments: { weight_kg: 70, height_cm: 170 },
+    }, 3, 'calculate_bmi');
+    const callResult = jsonRpcResult(called.message);
+    expect(called.response.headers.get('mcp-session-id')).toBeNull();
+    expect(callResult.resultType).toBe('complete');
+    expect(callResult.structuredContent).toMatchObject({
+      id: 'bmi', evidenceUri: 'calc://bmi/evidence',
+    });
   });
 
   it('closes the HTTP owner idempotently before an asynchronous bind completes', async () => {
@@ -190,7 +282,11 @@ describe('Node Streamable HTTP transport', () => {
 
   it('rejects JSON-RPC batches and oversized requests before transport dispatch', async () => {
     const url = await start();
-    for (const body of ['[]', `[${initializeBody}]`]) {
+    for (const body of [
+      '[]',
+      `[${initializeBody}]`,
+      JSON.stringify([modernJsonRpcRequest('tools/list')]),
+    ]) {
       const response = await fetch(`${url}/mcp`, {
         method: 'POST',
         headers: {
@@ -231,7 +327,13 @@ describe('Node Streamable HTTP transport', () => {
       body,
     });
 
-    for (const body of ['{}', 'null', '42', '{"jsonrpc":"2.0","id":1,"method":42}']) {
+    for (const body of [
+      '{}',
+      'null',
+      '42',
+      '{"jsonrpc":"2.0","id":1,"method":42}',
+      JSON.stringify({ ...modernJsonRpcRequest('tools/list'), method: 42 }),
+    ]) {
       const response = await request(body);
       expect(response.status, body).toBe(400);
       await expect(response.json()).resolves.toMatchObject({ error: { code: -32600 } });

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -3,9 +3,13 @@ import http from 'node:http';
 import { pathToFileURL } from 'node:url';
 import express from 'express';
 import { createMcpExpressApp } from '@modelcontextprotocol/express';
-import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
+import { toNodeHandler } from '@modelcontextprotocol/node';
 import { parseJSONRPCMessage } from '@modelcontextprotocol/server';
-import { buildServer, catalogMode, type CatalogMode } from './build-tools.js';
+import { catalogMode, type CatalogMode } from './build-tools.js';
+import {
+  createOathMcpHandler,
+  reportMcpInfrastructureError,
+} from './mcp-handler.js';
 import { originRejection, parseAllowedOrigins } from './origin.js';
 import {
   acceptsMediaType,
@@ -20,6 +24,15 @@ export interface HttpServerOptions {
   allowedOrigins?: ReadonlySet<string>;
 }
 
+interface OathHttpApp extends express.Express {
+  closeMcpHandler(): Promise<void>;
+}
+
+export interface RunningHttpServer {
+  server: http.Server;
+  close(): Promise<void>;
+}
+
 const methodNotAllowed = (_req: express.Request, res: express.Response): void => {
   res.set('Allow', 'POST').status(405).json({
     jsonrpc: '2.0',
@@ -28,8 +41,8 @@ const methodNotAllowed = (_req: express.Request, res: express.Response): void =>
   });
 };
 
-export function createHttpApp(options: HttpServerOptions): express.Express {
-  const app = express();
+export function createHttpApp(options: HttpServerOptions): OathHttpApp {
+  const app = express() as OathHttpApp;
   const allowedOrigins = options.allowedOrigins ?? new Set<string>();
   const allowedOriginHostnames = [...allowedOrigins]
     .map((origin) => new URL(origin).hostname);
@@ -37,6 +50,19 @@ export function createHttpApp(options: HttpServerOptions): express.Express {
     host: options.host,
     ...(allowedOriginHostnames.length === 0 ? {} : { allowedOrigins: allowedOriginHostnames }),
   });
+  const handler = createOathMcpHandler({ mode: options.mode ?? 'full' });
+  const nodeHandler = toNodeHandler({
+    fetch: async (request, requestOptions) => {
+      const response = await handler.fetch(request, requestOptions);
+      response.headers.set('Cache-Control', 'no-store');
+      return response;
+    },
+  }, { onerror: reportMcpInfrastructureError });
+  let closeMcpHandlerPromise: Promise<void> | undefined;
+  app.closeMcpHandler = () => {
+    closeMcpHandlerPromise ??= handler.close();
+    return closeMcpHandlerPromise;
+  };
 
   // This parent middleware runs before the SDK app's JSON parser and host
   // validation, so hostile browser requests are rejected before body parsing.
@@ -55,7 +81,7 @@ export function createHttpApp(options: HttpServerOptions): express.Express {
       res.set({
         'Access-Control-Allow-Origin': origin,
         'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Accept, Content-Type, MCP-Protocol-Version',
+        'Access-Control-Allow-Headers': 'Accept, Content-Type, MCP-Protocol-Version, Mcp-Method, Mcp-Name',
         'Access-Control-Max-Age': '86400',
         Vary: 'Origin',
       });
@@ -133,49 +159,28 @@ export function createHttpApp(options: HttpServerOptions): express.Express {
   app.use(mcpApp);
 
   app.post('/mcp', async (req, res) => {
-    try {
-      // Streamable HTTP carries exactly one JSON-RPC message per POST. JSON-RPC
-      // batches are not part of MCP and can produce ambiguous lifecycle/tool
-      // semantics across clients, so reject them before transport dispatch.
-      if (Array.isArray(req.body)) {
-        res.status(400).json({
-          jsonrpc: '2.0',
-          error: { code: -32600, message: 'Invalid Request: MCP does not support JSON-RPC batches.' },
-          id: null,
-        });
-        return;
-      }
-      try {
-        parseJSONRPCMessage(req.body);
-      } catch {
-        res.status(400).json({
-          jsonrpc: '2.0',
-          error: { code: -32600, message: 'Invalid Request' },
-          id: null,
-        });
-        return;
-      }
-      const server = buildServer({ mode: options.mode ?? 'full' });
-      const transport = new NodeStreamableHTTPServerTransport({
-        sessionIdGenerator: undefined,
-        enableJsonResponse: true,
+    // Streamable HTTP carries exactly one JSON-RPC message per POST. JSON-RPC
+    // batches are not part of MCP and can produce ambiguous lifecycle/tool
+    // semantics across clients, so reject them before transport dispatch.
+    if (Array.isArray(req.body)) {
+      res.status(400).json({
+        jsonrpc: '2.0',
+        error: { code: -32600, message: 'Invalid Request: MCP does not support JSON-RPC batches.' },
+        id: null,
       });
-      res.on('close', () => {
-        void transport.close();
-        void server.close();
-      });
-      await server.connect(transport);
-      await transport.handleRequest(req, res, req.body);
-    } catch {
-      console.error('Error handling MCP request.');
-      if (!res.headersSent) {
-        res.status(500).json({
-          jsonrpc: '2.0',
-          error: { code: -32603, message: 'Internal server error' },
-          id: null,
-        });
-      }
+      return;
     }
+    try {
+      parseJSONRPCMessage(req.body);
+    } catch {
+      res.status(400).json({
+        jsonrpc: '2.0',
+        error: { code: -32600, message: 'Invalid Request' },
+        id: null,
+      });
+      return;
+    }
+    await nodeHandler(req, res, req.body);
   });
   app.all('/mcp', methodNotAllowed);
 
@@ -208,8 +213,54 @@ export function createHttpApp(options: HttpServerOptions): express.Express {
 
 export function startHttpServer(
   options: HttpServerOptions & { port: number },
-): http.Server {
-  return createHttpApp(options).listen(options.port, options.host);
+): RunningHttpServer {
+  const app = createHttpApp(options);
+  const server = app.listen(options.port, options.host);
+  let serverClosed = false;
+  server.once('close', () => {
+    serverClosed = true;
+  });
+  let closePromise: Promise<void> | undefined;
+  return {
+    server,
+    close() {
+      closePromise ??= (async () => {
+        const readyToClose = server.listening || serverClosed
+          ? Promise.resolve()
+          : new Promise<void>((resolve, reject) => {
+            const cleanup = () => {
+              server.off('listening', onListening);
+              server.off('close', onClose);
+              server.off('error', onError);
+            };
+            const onListening = () => {
+              cleanup();
+              resolve();
+            };
+            const onClose = () => {
+              cleanup();
+              resolve();
+            };
+            const onError = (error: Error) => {
+              cleanup();
+              reject(error);
+            };
+            server.once('listening', onListening);
+            server.once('close', onClose);
+            server.once('error', onError);
+            if (server.listening) onListening();
+            else if (serverClosed) onClose();
+          });
+        await app.closeMcpHandler();
+        await readyToClose;
+        if (serverClosed) return;
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => error ? reject(error) : resolve());
+        });
+      })();
+      return closePromise;
+    },
+  };
 }
 
 function isEntrypoint(): boolean {
@@ -222,7 +273,8 @@ if (isEntrypoint()) {
   const host = process.env.HOST ?? '127.0.0.1';
   const mode = catalogMode(process.env.OATH_MCP_MODE);
   const allowedOrigins = parseAllowedOrigins(process.env.OATH_ALLOWED_ORIGINS);
-  startHttpServer({ port, host, mode, allowedOrigins }).once('listening', () => {
+  const running = startHttpServer({ port, host, mode, allowedOrigins });
+  running.server.once('listening', () => {
     console.error(`oath-mcp listening on http://${host}:${port}/mcp`);
   });
 }

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -2,9 +2,9 @@
 import http from 'node:http';
 import { pathToFileURL } from 'node:url';
 import express from 'express';
-import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/express.js';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { JSONRPCMessageSchema } from '@modelcontextprotocol/sdk/types.js';
+import { createMcpExpressApp } from '@modelcontextprotocol/express';
+import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
+import { parseJSONRPCMessage } from '@modelcontextprotocol/server';
 import { buildServer, catalogMode, type CatalogMode } from './build-tools.js';
 import { originRejection, parseAllowedOrigins } from './origin.js';
 import {
@@ -30,8 +30,13 @@ const methodNotAllowed = (_req: express.Request, res: express.Response): void =>
 
 export function createHttpApp(options: HttpServerOptions): express.Express {
   const app = express();
-  const mcpApp = createMcpExpressApp({ host: options.host });
   const allowedOrigins = options.allowedOrigins ?? new Set<string>();
+  const allowedOriginHostnames = [...allowedOrigins]
+    .map((origin) => new URL(origin).hostname);
+  const mcpApp = createMcpExpressApp({
+    host: options.host,
+    ...(allowedOriginHostnames.length === 0 ? {} : { allowedOrigins: allowedOriginHostnames }),
+  });
 
   // This parent middleware runs before the SDK app's JSON parser and host
   // validation, so hostile browser requests are rejected before body parsing.
@@ -140,7 +145,9 @@ export function createHttpApp(options: HttpServerOptions): express.Express {
         });
         return;
       }
-      if (!JSONRPCMessageSchema.safeParse(req.body).success) {
+      try {
+        parseJSONRPCMessage(req.body);
+      } catch {
         res.status(400).json({
           jsonrpc: '2.0',
           error: { code: -32600, message: 'Invalid Request' },
@@ -149,7 +156,7 @@ export function createHttpApp(options: HttpServerOptions): express.Express {
         return;
       }
       const server = buildServer({ mode: options.mode ?? 'full' });
-      const transport = new StreamableHTTPServerTransport({
+      const transport = new NodeStreamableHTTPServerTransport({
         sessionIdGenerator: undefined,
         enableJsonResponse: true,
       });

--- a/src/server/in-memory-client.ts
+++ b/src/server/in-memory-client.ts
@@ -1,5 +1,4 @@
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { Client, InMemoryTransport } from '@modelcontextprotocol/client';
 import { buildServer, type BuildServerOptions } from './build-tools.js';
 
 export async function connectInMemoryClient(
@@ -7,7 +6,12 @@ export async function connectInMemoryClient(
   options: BuildServerOptions = {},
 ) {
   const server = buildServer(options);
-  const client = new Client({ name, version: '1.0.0' });
+  // Linked in-memory clients are intentionally legacy-only fast test surfaces;
+  // modern serving has no in-memory entrypoint.
+  const client = new Client(
+    { name, version: '1.0.0' },
+    { versionNegotiation: { mode: 'legacy' } },
+  );
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
   return {

--- a/src/server/mcp-handler.ts
+++ b/src/server/mcp-handler.ts
@@ -1,0 +1,12 @@
+import { createMcpHandler, type McpHttpHandler } from '@modelcontextprotocol/server';
+import { buildServer, type BuildServerOptions } from './build-tools.js';
+
+export function reportMcpInfrastructureError(): void {
+  console.error('Error handling MCP request.');
+}
+
+export function createOathMcpHandler(
+  options: BuildServerOptions = {},
+): McpHttpHandler {
+  return createMcpHandler(() => buildServer(options), { legacy: 'stateless' });
+}

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -1,5 +1,6 @@
 /**
  * Server barrel — the `./server` subpath export. Embedders build their own
- * transport around `buildServer()`.
+ * transport around `buildServer()`. `buildServer(): McpServer` returns a
+ * TypeScript SDK v2 object; SDK v1 object interoperability is not retained.
  */
 export { buildServer } from './build-tools.js';

--- a/src/server/public-contract.test.ts
+++ b/src/server/public-contract.test.ts
@@ -35,20 +35,32 @@ describe('public MCP contracts', () => {
     expect(serialized).not.toContain('citation');
   });
 
-  it('exports draft-07 object schemas for canonical input and exact output values', () => {
-    const spec = loadSpec('oxygenation_index');
-    const input = z.toJSONSchema(buildCalculatorInputSchema(spec), {
-      target: 'draft-07',
+  it('exports draft 2020-12 object schemas for canonical inputs, aliases, and exact outputs', () => {
+    const input = z.toJSONSchema(buildCalculatorInputSchema(loadSpec('bmi')), {
+      target: 'draft-2020-12',
       io: 'input',
-    }) as { type?: string; properties?: Record<string, unknown>; additionalProperties?: boolean };
-    const output = z.toJSONSchema(buildCalcResultSchema(spec), {
-      target: 'draft-07',
+    }) as {
+      $schema?: string;
+      type?: string;
+      properties?: Record<string, { description?: string }>;
+      additionalProperties?: boolean;
+      allOf?: { anyOf?: { required?: string[] }[] }[];
+    };
+    const output = z.toJSONSchema(buildCalcResultSchema(loadSpec('oxygenation_index')), {
+      target: 'draft-2020-12',
       io: 'output',
-    }) as { type?: string; properties?: Record<string, unknown> };
+    }) as { $schema?: string; type?: string; properties?: Record<string, unknown> };
+    expect(input.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
     expect(input.type).toBe('object');
     expect(input.additionalProperties).toBe(false);
-    expect(input.properties).toHaveProperty('pao2');
-    expect(input.properties).not.toHaveProperty('PaO2');
+    expect(input.properties?.weight_kg?.description).toBe('Body weight in kilograms.');
+    expect(input.properties?.weight?.description)
+      .toBe('Compatibility alias for weight_kg. Prefer weight_kg.');
+    expect(input.allOf?.[0]?.anyOf).toEqual(expect.arrayContaining([
+      { required: ['weight'] },
+      { required: ['weight_kg'] },
+    ]));
+    expect(output.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
     expect(output.type).toBe('object');
     expect(output.properties).toHaveProperty('results');
     expect(output.properties).toHaveProperty('evidenceUri');
@@ -103,13 +115,15 @@ describe('public MCP contracts', () => {
     }
   });
 
-  it('keeps panel and compact dispatch schemas top-level objects', () => {
+  it('keeps panel and compact dispatch schemas as draft 2020-12 top-level objects', () => {
     for (const schema of [buildPanelResultSchema(), buildCompactDispatchResultSchema()]) {
-      const json = z.toJSONSchema(schema, { target: 'draft-07', io: 'output' }) as {
+      const json = z.toJSONSchema(schema, { target: 'draft-2020-12', io: 'output' }) as {
+        $schema?: string;
         type?: string;
         anyOf?: unknown;
         oneOf?: unknown;
       };
+      expect(json.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
       expect(json.type).toBe('object');
       expect(json.anyOf).toBeUndefined();
       expect(json.oneOf).toBeUndefined();

--- a/src/server/stdio.ts
+++ b/src/server/stdio.ts
@@ -3,9 +3,8 @@
  * Stdio entry — the `oath-mcp` bin, for local clients
  * (`npx oath-mcp` / `{ command, args }` client configs).
  */
-import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
+import { serveStdio } from '@modelcontextprotocol/server/stdio';
 import { buildServer, catalogMode } from './build-tools.js';
 
-await buildServer({ mode: catalogMode(process.env.OATH_MCP_MODE) }).connect(
-  new StdioServerTransport(),
-);
+const mode = catalogMode(process.env.OATH_MCP_MODE);
+void serveStdio(() => buildServer({ mode }), { legacy: 'serve' });

--- a/src/server/stdio.ts
+++ b/src/server/stdio.ts
@@ -3,7 +3,7 @@
  * Stdio entry — the `oath-mcp` bin, for local clients
  * (`npx oath-mcp` / `{ command, args }` client configs).
  */
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
 import { buildServer, catalogMode } from './build-tools.js';
 
 await buildServer({ mode: catalogMode(process.env.OATH_MCP_MODE) }).connect(

--- a/src/server/validation-case-runner.test.ts
+++ b/src/server/validation-case-runner.test.ts
@@ -3,6 +3,15 @@ import { executeValidationCases } from '../validation/case-runner.js';
 import { ValidationDossierSchema } from '../validation/schema.js';
 import { createValidationCaseRunner, throwClinicalSurfaceFailure } from './validation-case-runner.js';
 
+function thrownBy(operation: () => never): unknown {
+  try {
+    operation();
+  } catch (error) {
+    return error;
+  }
+  throw new Error('Expected operation to throw.');
+}
+
 describe('production validation case runner', () => {
   it('executes engine, full direct MCP, and compact MCP with exact parity', async () => {
     const dossier = ValidationDossierSchema.parse({
@@ -162,5 +171,37 @@ describe('production validation case runner', () => {
     });
     expect(() => throwClinicalSurfaceFailure('bmi', { height_cm: 170 }, driftedPayload))
       .toThrow('drifted public message');
+
+    const wrongTool = new Error(
+      'Input validation error: Invalid arguments for tool calculate_gfr: height_cm: Invalid input: expected number, received undefined',
+    );
+    expect(() => throwClinicalSurfaceFailure('bmi', { weight_kg: 70 }, wrongTool))
+      .toThrow('Invalid arguments for tool calculate_gfr');
+  });
+
+  it('normalizes v2 humanized and dotted Standard Schema paths', () => {
+    expect(thrownBy(() => throwClinicalSurfaceFailure(
+      'bmi',
+      { weight_kg: 70 },
+      new Error('Input validation error: Invalid arguments for tool calculate_bmi: height_cm: Invalid input: expected number, received undefined'),
+    ))).toMatchObject({ code: 'MISSING_REQUIRED', field: 'height_cm' });
+
+    expect(thrownBy(() => throwClinicalSurfaceFailure(
+      'bmi',
+      { weight_kg: 0.4, height_cm: 170 },
+      new Error('Input validation error: Invalid arguments for tool calculate_bmi: weight_kg: Too small: expected number to be >=0.5'),
+    ))).toMatchObject({ code: 'OUT_OF_HARD_LIMITS', field: 'weight_kg' });
+
+    expect(thrownBy(() => throwClinicalSurfaceFailure(
+      'gfr',
+      { creatinine: { value: 1, unit: 'bogus' }, age: 60, sex: 'male' },
+      new Error('Input validation error: Invalid arguments for tool calculate_gfr: creatinine.unit: Expected one of: mg/dL | umol/L'),
+    ))).toMatchObject({ code: 'UNKNOWN_UNIT', field: 'creatinine' });
+
+    expect(thrownBy(() => throwClinicalSurfaceFailure(
+      'gfr',
+      { creatinine: { value: 0, unit: 'mg/dL' }, age: 60, sex: 'male' },
+      new Error('Input validation error: Invalid arguments for tool calculate_gfr: creatinine.value: Expected 0.01–60 mg/dL'),
+    ))).toMatchObject({ code: 'OUT_OF_HARD_LIMITS', field: 'creatinine' });
   });
 });

--- a/src/server/validation-case-runner.ts
+++ b/src/server/validation-case-runner.ts
@@ -41,22 +41,25 @@ type BoundaryFailureKind = 'required' | 'unknown' | 'hard_limit' | 'enum' | 'uni
 function schemaBoundaryFailure(
   error: unknown,
   inputs: Readonly<Record<string, unknown>>,
-): { kind: BoundaryFailureKind; field: string } | undefined {
+): { kind: BoundaryFailureKind; field: string; toolName?: string } | undefined {
   const actual = error as { field?: unknown; message?: unknown };
   const message = typeof actual.message === 'string' ? actual.message : '';
   const required = /Required input: ([a-zA-Z0-9_]+)/.exec(message);
   const unknown = /"keys":\s*\[\s*"([^"]+)"/.exec(message) ??
     /Unrecognized key(?:s)?:?\s*"([^"]+)"/.exec(message);
   const paths = [...message.matchAll(/"path":\s*\[\s*"([^"]+)"/g)];
+  const humanizedPath = /Invalid arguments for tool ([^:]+):\s*([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)*):/.exec(message);
   const invalidUnion = /"code":\s*"invalid_union"/.test(message);
-  const genericInvalidInput = invalidUnion || message === 'Invalid input';
+  const genericInvalidInput = invalidUnion || /(?:^|: )Invalid input(?:$|:)/.test(message);
   const path = invalidUnion ? paths[paths.length - 1] : paths[0];
+  const humanizedField = humanizedPath?.[2]?.split('.')[0];
+  const toolName = humanizedPath?.[1];
   const structuredField = typeof actual.field === 'string' && actual.field !== '' && actual.field !== 'inputs'
     ? actual.field.split('.')[0]
     : undefined;
-  const field = required?.[1] ?? unknown?.[1] ?? path?.[1] ?? structuredField;
+  const field = required?.[1] ?? unknown?.[1] ?? path?.[1] ?? humanizedField ?? structuredField;
   if (field === undefined) return undefined;
-  if (required !== null) return { kind: 'required', field };
+  if (required !== null) return { kind: 'required', field, toolName };
   // Zod reports a missing canonical (non-alias) input as an invalid type whose
   // received value is undefined. Treat that boundary spelling as the same
   // missing-input discriminant emitted by the engine.
@@ -65,19 +68,19 @@ function schemaBoundaryFailure(
     /Invalid option:/.test(message) ||
     genericInvalidInput
   )) {
-    return { kind: 'required', field };
+    return { kind: 'required', field, toolName };
   }
-  if (unknown !== null) return { kind: 'unknown', field };
+  if (unknown !== null) return { kind: 'unknown', field, toolName };
   if (/Too (?:small|big):/.test(message) || /Expected [^\n]+–[^\n]+/.test(message)) {
-    return { kind: 'hard_limit', field };
+    return { kind: 'hard_limit', field, toolName };
   }
-  if (/Invalid option:/.test(message)) return { kind: 'enum', field };
-  if (/Expected one of:/.test(message)) return { kind: 'unit', field };
+  if (/Invalid option:/.test(message)) return { kind: 'enum', field, toolName };
+  if (/Expected one of:/.test(message)) return { kind: 'unit', field, toolName };
   if (/Provide [a-zA-Z0-9_]+ once; do not combine it with compatibility aliases\./.test(message)) {
-    return { kind: 'alias', field };
+    return { kind: 'alias', field, toolName };
   }
   if (genericInvalidInput || /Invalid input: expected/.test(message)) {
-    return { kind: 'type', field };
+    return { kind: 'type', field, toolName };
   }
   return undefined;
 }
@@ -96,9 +99,11 @@ export function throwClinicalSurfaceFailure(
   calculatorId: string,
   inputs: Record<string, unknown>,
   mcpError: unknown,
+  expectedToolName = `calculate_${calculatorId}`,
 ): never {
   const boundary = schemaBoundaryFailure(mcpError, inputs);
   if (boundary === undefined) throw mcpError;
+  if (boundary.toolName !== undefined && boundary.toolName !== expectedToolName) throw mcpError;
   let engineError: EngineError | undefined;
   try {
     run(calculatorId, structuredClone(inputs));
@@ -119,12 +124,13 @@ export function throwClinicalSurfaceFailure(
 async function callClinicalSurface<T>(
   calculatorId: string,
   inputs: Record<string, unknown>,
+  expectedToolName: string,
   operation: () => Promise<T>,
 ): Promise<T> {
   try {
     return await operation();
   } catch (error) {
-    throwClinicalSurfaceFailure(calculatorId, inputs, error);
+    throwClinicalSurfaceFailure(calculatorId, inputs, error, expectedToolName);
   }
 }
 
@@ -157,7 +163,7 @@ export async function createValidationCaseRunner(): Promise<ManagedValidationCas
   return {
     runEngine: async (calculatorId, inputs) => run(calculatorId, inputs),
     runFullMcp: async (calculatorId, inputs) => {
-      const result = await callClinicalSurface(calculatorId, inputs, () =>
+      const result = await callClinicalSurface(calculatorId, inputs, `calculate_${calculatorId}`, () =>
         full.client.callTool({ name: `calculate_${calculatorId}`, arguments: inputs }));
       if (result.isError) {
         const first = (result.content as { type: string; text?: string }[])[0];
@@ -174,7 +180,7 @@ export async function createValidationCaseRunner(): Promise<ManagedValidationCas
       return clinicalPayload(result.structuredContent);
     },
     runCompactMcp: async (calculatorId, inputs) => {
-      const response = await callClinicalSurface(calculatorId, inputs, () =>
+      const response = await callClinicalSurface(calculatorId, inputs, 'calculate', () =>
         compact.client.callTool({
           name: 'calculate',
           arguments: { id: calculatorId, inputs },

--- a/src/server/worker.test.ts
+++ b/src/server/worker.test.ts
@@ -10,13 +10,13 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { describe, it, expect } from 'vitest';
-import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
 import { loadSpecs, primeSpecs } from '../engine/index.js';
 import { SPEC_TEXTS, PKG_VERSION } from './spec-data.generated.js';
 import worker from './worker.js';
 
 const SPECS_DIR = join(dirname(fileURLToPath(import.meta.url)), '../../specs');
 const WRANGLER_CONFIG = join(SPECS_DIR, '../wrangler.jsonc');
+const LEGACY_PROTOCOL_VERSION = '2025-11-25';
 
 describe('spec-data.generated.ts', () => {
   it('matches specs/*.yaml exactly (run `npm run gen:specs` if this fails)', () => {
@@ -47,7 +47,7 @@ const initializeBody = JSON.stringify({
   id: 1,
   method: 'initialize',
   params: {
-    protocolVersion: LATEST_PROTOCOL_VERSION,
+    protocolVersion: LEGACY_PROTOCOL_VERSION,
     capabilities: {},
     clientInfo: { name: 'worker-test', version: '0.0.0' },
   },

--- a/src/server/worker.test.ts
+++ b/src/server/worker.test.ts
@@ -14,6 +14,10 @@ import { describe, it, expect } from 'vitest';
 import {
   LEGACY_PROTOCOL_VERSION,
   MODERN_PROTOCOL_VERSION,
+  exchangeJsonRpc,
+  jsonRpcResult,
+  modernJsonRpcRequest,
+  modernRequestHeaders,
 } from '../../test/support/protocol-fixtures.js';
 import { loadSpecs, primeSpecs } from '../engine/index.js';
 import { SPEC_TEXTS, PKG_VERSION } from './spec-data.generated.js';
@@ -56,6 +60,17 @@ const initializeBody = JSON.stringify({
     clientInfo: { name: 'worker-test', version: '0.0.0' },
   },
 });
+
+function postRaw(
+  body: unknown,
+  headers: Record<string, string> = {},
+) {
+  return exchangeJsonRpc(
+    body,
+    (init) => worker.fetch(new Request('https://worker.example/mcp', init)),
+    headers,
+  );
+}
 
 describe('Worker Streamable HTTP transport', () => {
   it('redirects plaintext requests and applies HSTS to every HTTPS response', async () => {
@@ -182,6 +197,66 @@ describe('Worker Streamable HTTP transport', () => {
     }
   });
 
+  it('keeps raw legacy responses free of modern wire and session fields', async () => {
+    const initialized = await postRaw(JSON.parse(initializeBody));
+    expect(initialized.response.status).toBe(200);
+    expect(initialized.response.headers.get('mcp-session-id')).toBeNull();
+    expect(jsonRpcResult(initialized.message).protocolVersion).toBe(LEGACY_PROTOCOL_VERSION);
+
+    const listed = await postRaw({
+      jsonrpc: '2.0', id: 2, method: 'tools/list', params: {},
+    }, { 'MCP-Protocol-Version': LEGACY_PROTOCOL_VERSION });
+    const result = jsonRpcResult(listed.message);
+    expect(listed.response.status).toBe(200);
+    expect(listed.response.headers.get('mcp-session-id')).toBeNull();
+    expect(result).not.toHaveProperty('resultType');
+    expect(result).not.toHaveProperty('ttlMs');
+    expect(result).not.toHaveProperty('cacheScope');
+    expect(result).not.toHaveProperty('_meta');
+  });
+
+  it('serves raw modern discovery, lists, and a complete BMI call', async () => {
+    const modernPost = (
+      method: string,
+      params: Record<string, unknown>,
+      id: number,
+      name?: string,
+    ) => postRaw(
+      modernJsonRpcRequest(method, params, { id, clientName: 'raw-worker-modern' }),
+      modernRequestHeaders(method, name),
+    );
+
+    const discovered = await modernPost('server/discover', {}, 1);
+    expect(discovered.response.status).toBe(200);
+    expect(discovered.response.headers.get('mcp-session-id')).toBeNull();
+    expect(jsonRpcResult(discovered.message)).toMatchObject({
+      resultType: 'complete',
+      ttlMs: 0,
+      cacheScope: 'private',
+      supportedVersions: expect.arrayContaining([MODERN_PROTOCOL_VERSION]),
+    });
+
+    const listed = await modernPost('tools/list', {}, 2);
+    const listResult = jsonRpcResult(listed.message);
+    expect(listed.response.headers.get('mcp-session-id')).toBeNull();
+    expect(listResult).toMatchObject({
+      resultType: 'complete', ttlMs: 0, cacheScope: 'private',
+    });
+    expect((listResult.tools as { name: string }[]).map(({ name }) => name))
+      .toContain('calculate_bmi');
+
+    const called = await modernPost('tools/call', {
+      name: 'calculate_bmi',
+      arguments: { weight_kg: 70, height_cm: 170 },
+    }, 3, 'calculate_bmi');
+    const callResult = jsonRpcResult(called.message);
+    expect(called.response.headers.get('mcp-session-id')).toBeNull();
+    expect(callResult.resultType).toBe('complete');
+    expect(callResult.structuredContent).toMatchObject({
+      id: 'bmi', evidenceUri: 'calc://bmi/evidence',
+    });
+  });
+
   it('accepts the checked-in production documentation origin', async () => {
     const config = readFileSync(WRANGLER_CONFIG, 'utf8');
     const configuredOrigins = /"OATH_ALLOWED_ORIGINS"\s*:\s*"([^"]+)"/.exec(config)?.[1];
@@ -231,7 +306,11 @@ describe('Worker Streamable HTTP transport', () => {
   });
 
   it('rejects JSON-RPC batches and oversized requests before transport dispatch', async () => {
-    for (const body of ['[]', `[${initializeBody}]`]) {
+    for (const body of [
+      '[]',
+      `[${initializeBody}]`,
+      JSON.stringify([modernJsonRpcRequest('tools/list')]),
+    ]) {
       const response = await worker.fetch(new Request('https://worker.example/mcp', {
         method: 'POST',
         headers: {
@@ -349,7 +428,13 @@ describe('Worker Streamable HTTP transport', () => {
       body,
     }));
 
-    for (const body of ['{}', 'null', '42', '{"jsonrpc":"2.0","id":1,"method":42}']) {
+    for (const body of [
+      '{}',
+      'null',
+      '42',
+      '{"jsonrpc":"2.0","id":1,"method":42}',
+      JSON.stringify({ ...modernJsonRpcRequest('tools/list'), method: 42 }),
+    ]) {
       const response = await request(body);
       expect(response.status, body).toBe(400);
       await expect(response.json()).resolves.toMatchObject({ error: { code: -32600 } });

--- a/src/server/worker.test.ts
+++ b/src/server/worker.test.ts
@@ -9,14 +9,18 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import { describe, it, expect } from 'vitest';
+import {
+  LEGACY_PROTOCOL_VERSION,
+  MODERN_PROTOCOL_VERSION,
+} from '../../test/support/protocol-fixtures.js';
 import { loadSpecs, primeSpecs } from '../engine/index.js';
 import { SPEC_TEXTS, PKG_VERSION } from './spec-data.generated.js';
 import worker from './worker.js';
 
 const SPECS_DIR = join(dirname(fileURLToPath(import.meta.url)), '../../specs');
 const WRANGLER_CONFIG = join(SPECS_DIR, '../wrangler.jsonc');
-const LEGACY_PROTOCOL_VERSION = '2025-11-25';
 
 describe('spec-data.generated.ts', () => {
   it('matches specs/*.yaml exactly (run `npm run gen:specs` if this fails)', () => {
@@ -134,8 +138,10 @@ describe('Worker Streamable HTTP transport', () => {
     });
     expect(noOrigin.status).toBe(200);
     expect(allowed.status).toBe(200);
-    expect(noOrigin.headers.get('content-type')).toBe('application/json');
-    expect(allowed.headers.get('content-type')).toBe('application/json');
+    expect(['application/json', 'text/event-stream'])
+      .toContain(noOrigin.headers.get('content-type'));
+    expect(['application/json', 'text/event-stream'])
+      .toContain(allowed.headers.get('content-type'));
     expect(noOrigin.headers.get('cache-control')).toBe('no-store');
     expect(allowed.headers.get('access-control-allow-origin')).toBe('https://app.example');
     const hostile = await worker.fetch(request('https://evil.example'), {
@@ -152,6 +158,28 @@ describe('Worker Streamable HTTP transport', () => {
     expect(preflight.status).toBe(204);
     expect(preflight.headers.get('access-control-allow-origin')).toBe('https://app.example');
     expect(preflight.headers.get('access-control-allow-methods')).toContain('POST');
+    expect(preflight.headers.get('access-control-allow-headers'))
+      .toBe('accept, content-type, mcp-protocol-version, mcp-method, mcp-name');
+  });
+
+  it('serves a modern discovery and tools list through the shared handler', async () => {
+    const client = new Client(
+      { name: 'worker-modern-smoke', version: '0.0.0' },
+      { versionNegotiation: { mode: { pin: MODERN_PROTOCOL_VERSION } } },
+    );
+    const transport = new StreamableHTTPClientTransport(
+      new URL('https://worker.example/mcp'),
+      { fetch: async (input, init) => worker.fetch(new Request(input, init)) },
+    );
+    try {
+      await client.connect(transport);
+      expect(client.getProtocolEra()).toBe('modern');
+      expect(client.getDiscoverResult()).toBeDefined();
+      const { tools } = await client.listTools();
+      expect(tools.map(({ name }) => name)).toContain('calculate_bmi');
+    } finally {
+      await client.close();
+    }
   });
 
   it('accepts the checked-in production documentation origin', async () => {

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -12,8 +12,10 @@
  * `buildServer()`. Regenerate that module with `npm run gen:specs` (runs
  * automatically on `npm run build`).
  */
-import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
-import { JSONRPCMessageSchema } from '@modelcontextprotocol/sdk/types.js';
+import {
+  parseJSONRPCMessage,
+  WebStandardStreamableHTTPServerTransport,
+} from '@modelcontextprotocol/server';
 import { primeSpecs } from '../engine/index.js';
 import { buildServer, catalogMode } from './build-tools.js';
 import { originRejection, parseAllowedOrigins } from './origin.js';
@@ -314,7 +316,9 @@ async function handleRequest(request: Request, env: WorkerEnv): Promise<Response
           400,
         ), origin, origins);
       }
-      if (!JSONRPCMessageSchema.safeParse(parsedBody).success) {
+      try {
+        parseJSONRPCMessage(parsedBody);
+      } catch {
         return withCors(jsonResponse(
           { jsonrpc: '2.0', error: { code: -32600, message: 'Invalid Request' }, id: null },
           400,

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -1,10 +1,9 @@
 /**
  * Cloudflare Workers entry — stateless streamable HTTP over the SDK's
  * web-standard transport (fetch `Request` → `Response`). No sessions, no Durable
- * Objects, no paid plan. A fresh `McpServer` is built per request (the SDK
- * forbids reconnecting a connected server); the derived tool/prompt/resource
- * definitions are memoized in module scope, so per-request cost is just object
- * construction.
+ * Objects, no paid plan. Module-scoped dual-era handlers build a fresh
+ * `McpServer` per request; derived tool/prompt/resource definitions remain
+ * memoized in module scope.
  *
  * Workers has no filesystem, so `loadSpecs()`'s disk path (`node:fs` +
  * `readdirSync`) is never reachable here: we prime the spec cache and the server
@@ -12,12 +11,10 @@
  * `buildServer()`. Regenerate that module with `npm run gen:specs` (runs
  * automatically on `npm run build`).
  */
-import {
-  parseJSONRPCMessage,
-  WebStandardStreamableHTTPServerTransport,
-} from '@modelcontextprotocol/server';
+import { parseJSONRPCMessage } from '@modelcontextprotocol/server';
 import { primeSpecs } from '../engine/index.js';
-import { buildServer, catalogMode } from './build-tools.js';
+import { catalogMode } from './build-tools.js';
+import { createOathMcpHandler } from './mcp-handler.js';
 import { originRejection, parseAllowedOrigins } from './origin.js';
 import { SPEC_TEXTS, PKG_VERSION } from './spec-data.generated.js';
 import { RESPONSIBLE_USE_TEXT } from './responsible-use.generated.js';
@@ -31,6 +28,8 @@ import {
 // One-time init per isolate: validate + cache the bundled specs and pin the
 // version. Runs at module load (before any request), replacing the fs read.
 primeSpecs(SPEC_TEXTS);
+const fullHandler = createOathMcpHandler({ mode: 'full', version: PKG_VERSION });
+const compactHandler = createOathMcpHandler({ mode: 'compact', version: PKG_VERSION });
 
 export type WorkerEnv = Partial<Env> & {
   /** Portal-generated token; install as a Worker secret and never commit it. */
@@ -127,7 +126,10 @@ function corsHeaders(origin: string | null, allowed: ReadonlySet<string>): Heade
   if (origin !== null && allowed.has(origin)) {
     headers.set('access-control-allow-origin', origin);
     headers.set('access-control-allow-methods', 'POST, OPTIONS');
-    headers.set('access-control-allow-headers', 'accept, content-type, mcp-protocol-version');
+    headers.set(
+      'access-control-allow-headers',
+      'accept, content-type, mcp-protocol-version, mcp-method, mcp-name',
+    );
     headers.set('access-control-max-age', '86400');
     headers.set('vary', 'Origin');
   }
@@ -324,24 +326,14 @@ async function handleRequest(request: Request, env: WorkerEnv): Promise<Response
           400,
         ), origin, origins);
       }
-      const server = buildServer({
-        mode: catalogMode(env.OATH_MCP_MODE),
-        version: PKG_VERSION,
-      });
-      const transport = new WebStandardStreamableHTTPServerTransport({
-        sessionIdGenerator: undefined, // stateless
-        enableJsonResponse: true, // plain JSON responses (no SSE) — a calculator needs no streaming
-      });
-      try {
-        await server.connect(transport);
-        return withCors(
-          await transport.handleRequest(request, { parsedBody }),
-          origin,
-          origins,
-        );
-      } finally {
-        await Promise.allSettled([transport.close(), server.close()]);
-      }
+      const handler = catalogMode(env.OATH_MCP_MODE) === 'compact'
+        ? compactHandler
+        : fullHandler;
+      return withCors(
+        await handler.fetch(request, { parsedBody }),
+        origin,
+        origins,
+      );
     } catch {
       // handleRequest returns well-formed JSON-RPC error Responses for parse/
       // protocol/tool faults itself; this only catches a genuine infrastructure

--- a/test/agent-eval/eval.test.ts
+++ b/test/agent-eval/eval.test.ts
@@ -12,7 +12,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { describe, expect, it, beforeAll } from 'vitest';
-import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import type { Client } from '@modelcontextprotocol/client';
 import {
   loadSpec,
   loadSpecs,

--- a/test/check-worker-bundle.test.ts
+++ b/test/check-worker-bundle.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  assertBelowFreeLimit,
+  checkWorkerBundle,
+  parseGzipSize,
+} from '../scripts/check-worker-bundle.mjs';
+
+describe('Worker bundle-size gate', () => {
+  it.each([
+    ['Total Upload: 857.34 KiB / gzip: 220.78 KiB', 220.78 * 1024],
+    ['Total Upload: 4.00 MiB / gzip: 2.50 MiB', 2.5 * 1024 ** 2],
+  ])('normalizes Wrangler output: %s', (output, bytes) => {
+    expect(parseGzipSize(output).bytes).toBe(bytes);
+  });
+
+  it('fails when Wrangler omits the gzip total', () => {
+    expect(() => parseGzipSize('Total Upload: 857.34 KiB')).toThrow(
+      'Wrangler output did not report a gzip bundle size',
+    );
+  });
+
+  it('rejects the exact Cloudflare Free 3 MiB limit', () => {
+    expect(() => assertBelowFreeLimit(parseGzipSize(
+      'Total Upload: 4.00 MiB / gzip: 3.00 MiB',
+    ))).toThrow('must remain below 3 MiB');
+  });
+
+  it('preserves a failed Wrangler exit code without reporting success', async () => {
+    const log = vi.fn();
+    const exitCode = await checkWorkerBundle({
+      log,
+      runWrangler: async () => ({ exitCode: 17, stderr: 'failed', stdout: '' }),
+    });
+
+    expect(exitCode).toBe(17);
+    expect(log).not.toHaveBeenCalled();
+  });
+});

--- a/test/ci-workflows.test.ts
+++ b/test/ci-workflows.test.ts
@@ -23,9 +23,13 @@ function loadWorkflow(path: string): Workflow {
   return YAML.parse(readFileSync(path, 'utf8')) as Workflow;
 }
 
-function runCommands(workflow: Workflow): string[] {
-  return Object.values(workflow.jobs)
-    .flatMap((job) => job.steps ?? [])
+function runCommands(workflow: Workflow, jobName?: string): string[] {
+  const job = jobName === undefined ? undefined : workflow.jobs[jobName];
+  const jobs = jobName === undefined
+    ? Object.values(workflow.jobs)
+    : job === undefined ? [] : [job];
+  return jobs
+    .flatMap((entry) => entry.steps ?? [])
     .flatMap((step) => step.run === undefined ? [] : [step.run]);
 }
 
@@ -35,20 +39,25 @@ describe('GitHub workflow boundaries', () => {
 
     expect(workflow.on.push?.branches).toEqual(['main']);
     expect(Object.hasOwn(workflow.on, 'pull_request')).toBe(true);
-    expect(runCommands(workflow)).toContain('npm run check');
+    expect(runCommands(workflow, 'check')).toEqual(expect.arrayContaining([
+      'npm run check',
+      'npm run check:worker',
+    ]));
     expect(runCommands(workflow)).not.toContain('npm run check:clinical-release');
-    expect(runCommands(workflow.jobs.docs === undefined
-      ? { ...workflow, jobs: {} }
-      : { ...workflow, jobs: { docs: workflow.jobs.docs } })).toContain('npm run check');
+    expect(runCommands(workflow, 'docs')).toContain('npm run check');
   });
 
   it('validates, deploys both Workers, verifies production, and publishes only from version tags', () => {
     const workflow = loadWorkflow('.github/workflows/release-readiness.yml');
     const commands = runCommands(workflow);
+    const validateReleaseCommands = runCommands(workflow, 'validate-release');
 
     expect(workflow.on.push?.tags).toEqual(['v*']);
     expect(Object.hasOwn(workflow.on, 'workflow_dispatch')).toBe(true);
-    expect(commands).toContain('npm run check:release');
+    expect(validateReleaseCommands).toEqual(expect.arrayContaining([
+      'npm run check:release',
+      'npm run check:worker',
+    ]));
     expect(commands).toContain('npm run verify:production');
     expect(commands.some((command) => command.includes('npm publish --access public'))).toBe(true);
     expect(commands.some((command) => command.includes('npm run check:release-metadata -- --tag'))).toBe(true);
@@ -57,6 +66,7 @@ describe('GitHub workflow boundaries', () => {
     expect(commands.some((command) => command.includes('gh release create'))).toBe(true);
 
     expect(workflow.jobs['deploy-production']?.if).toContain("refs/tags/v");
+    expect(workflow.jobs['deploy-production']?.needs).toBe('validate-release');
     expect(workflow.jobs['verify-production']?.needs).toBe('deploy-production');
     expect(workflow.jobs['publish-npm']?.if).toContain('NPM_PUBLISH_ENABLED');
     expect(workflow.jobs['deploy-production']?.environment).toMatchObject({ name: 'production' });

--- a/test/package-manifest.test.ts
+++ b/test/package-manifest.test.ts
@@ -8,7 +8,18 @@ interface PackManifest {
 }
 
 interface PackageJson {
+  bundledDependencies?: string[];
+  bundleDependencies?: string[];
+  dependencies: Record<string, string>;
+  devDependencies: Record<string, string>;
   exports: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  overrides?: Record<string, unknown>;
+  peerDependencies?: Record<string, string>;
+}
+
+interface PackageLock {
+  packages: Record<string, unknown>;
 }
 
 describe('published package manifest', () => {
@@ -52,10 +63,45 @@ describe('published package manifest', () => {
     ]) expect(files).toContain(publicDocument);
 
     const packageJson = JSON.parse(readFileSync('package.json', 'utf8')) as PackageJson;
+    expect(packageJson.dependencies).toMatchObject({
+      '@modelcontextprotocol/express': '^2.0.0',
+      '@modelcontextprotocol/node': '^2.0.0',
+      '@modelcontextprotocol/server': '^2.0.0',
+    });
+    expect(packageJson.devDependencies['@modelcontextprotocol/client']).toBe('^2.0.0');
+    for (const runtimeDependencies of [
+      packageJson.dependencies,
+      packageJson.optionalDependencies ?? {},
+      packageJson.peerDependencies ?? {},
+    ]) {
+      expect(runtimeDependencies).not.toHaveProperty('@modelcontextprotocol/client');
+      expect(runtimeDependencies).not.toHaveProperty('@modelcontextprotocol/sdk');
+    }
+    for (const dependencySurface of [packageJson.dependencies, packageJson.devDependencies]) {
+      expect(dependencySurface).not.toHaveProperty('@modelcontextprotocol/sdk');
+    }
+    for (const bundled of [
+      packageJson.bundledDependencies ?? [],
+      packageJson.bundleDependencies ?? [],
+    ]) {
+      expect(bundled).not.toContain('@modelcontextprotocol/client');
+      expect(bundled).not.toContain('@modelcontextprotocol/sdk');
+    }
+    expect(packageJson.overrides ?? {}).not.toHaveProperty('@hono/node-server');
+    const packageLock = JSON.parse(readFileSync('package-lock.json', 'utf8')) as PackageLock;
+    expect(Object.keys(packageLock.packages).some((path) =>
+      path === 'node_modules/@modelcontextprotocol/sdk'
+      || path.endsWith('/node_modules/@modelcontextprotocol/sdk'))).toBe(false);
     expect(packageJson.exports).toEqual({
       '.': './dist/engine/index.js',
       './server': './dist/server/mcp.js',
     });
+
+    for (const internalHelper of [
+      'in-memory-client', 'compatibility', 'validation-case-runner',
+    ]) {
+      expect(files.some((path) => path.startsWith(`dist/server/${internalHelper}.`))).toBe(false);
+    }
 
     const packedFiles = new Set(files);
     const markdownLink = /!?\[[^\]]*\]\((<[^>]+>|[^)\s]+)(?:\s+"[^"]*")?\)/g;

--- a/test/release/verify-production.test.ts
+++ b/test/release/verify-production.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { loadSpecs } from '../../src/engine/index.js';
+import { PKG_VERSION } from '../../src/server/spec-data.generated.js';
+import { verifyMcpSurface } from '../../scripts/release/verify-production.mjs';
+import { startLoopbackHttp } from '../support/transport-harness.js';
+
+describe('production MCP verifier', () => {
+  it('proves the local compact endpoint in modern and legacy eras', async () => {
+    const server = await startLoopbackHttp({ mode: 'compact' });
+    try {
+      await expect(verifyMcpSurface(server.url.origin, {
+        version: PKG_VERSION,
+        attestation: { calculatorIds: [...loadSpecs().keys()] },
+        newCalculatorIds: ['bmi'],
+      })).resolves.toBeUndefined();
+    } finally {
+      await server.close();
+    }
+  }, 60_000);
+});

--- a/test/support/mcp-client.ts
+++ b/test/support/mcp-client.ts
@@ -1,5 +1,4 @@
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { Client, InMemoryTransport } from '@modelcontextprotocol/client';
 import { buildServer } from '../../src/server/build-tools.js';
 import type { BuildServerOptions } from '../../src/server/build-tools.js';
 
@@ -9,7 +8,12 @@ export async function connectTestClient(
   options: BuildServerOptions = {},
 ): Promise<Client> {
   const server = buildServer(options);
-  const client = new Client({ name, version: '0.0.0' });
+  // Linked in-memory clients are intentionally legacy-only fast test surfaces;
+  // modern serving has no in-memory entrypoint.
+  const client = new Client(
+    { name, version: '0.0.0' },
+    { versionNegotiation: { mode: 'legacy' } },
+  );
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
   return client;

--- a/test/support/protocol-fixtures.ts
+++ b/test/support/protocol-fixtures.ts
@@ -1,0 +1,23 @@
+export const LEGACY_PROTOCOL_VERSION = '2025-11-25';
+export const MODERN_PROTOCOL_VERSION = '2026-07-28';
+
+export type ProtocolEra = 'legacy' | 'modern';
+
+export function modernRequestMeta(clientName = 'oathmcp-test') {
+  return {
+    'io.modelcontextprotocol/protocolVersion': MODERN_PROTOCOL_VERSION,
+    'io.modelcontextprotocol/clientInfo': { name: clientName, version: '0.0.0' },
+    'io.modelcontextprotocol/clientCapabilities': {},
+  };
+}
+
+export function modernRequestHeaders(
+  method: string,
+  name?: string,
+): Record<string, string> {
+  return {
+    'MCP-Protocol-Version': MODERN_PROTOCOL_VERSION,
+    'Mcp-Method': method,
+    ...(name === undefined ? {} : { 'Mcp-Name': name }),
+  };
+}

--- a/test/support/protocol-fixtures.ts
+++ b/test/support/protocol-fixtures.ts
@@ -1,11 +1,21 @@
+import type { VersionNegotiationOptions } from '@modelcontextprotocol/client';
+
 export const LEGACY_PROTOCOL_VERSION = '2025-11-25';
 export const MODERN_PROTOCOL_VERSION = '2026-07-28';
+export const UNSUPPORTED_MODERN_PROTOCOL_VERSION = '2099-01-01';
 
 export type ProtocolEra = 'legacy' | 'modern';
 
-export function modernRequestMeta(clientName = 'oathmcp-test') {
+export function versionNegotiationForEra(era: ProtocolEra): VersionNegotiationOptions {
+  return { mode: era === 'legacy' ? 'legacy' : { pin: MODERN_PROTOCOL_VERSION } };
+}
+
+export function modernRequestMeta(
+  clientName = 'oathmcp-test',
+  protocolVersion = MODERN_PROTOCOL_VERSION,
+) {
   return {
-    'io.modelcontextprotocol/protocolVersion': MODERN_PROTOCOL_VERSION,
+    'io.modelcontextprotocol/protocolVersion': protocolVersion,
     'io.modelcontextprotocol/clientInfo': { name: clientName, version: '0.0.0' },
     'io.modelcontextprotocol/clientCapabilities': {},
   };
@@ -14,10 +24,81 @@ export function modernRequestMeta(clientName = 'oathmcp-test') {
 export function modernRequestHeaders(
   method: string,
   name?: string,
+  protocolVersion = MODERN_PROTOCOL_VERSION,
 ): Record<string, string> {
   return {
-    'MCP-Protocol-Version': MODERN_PROTOCOL_VERSION,
+    'MCP-Protocol-Version': protocolVersion,
     'Mcp-Method': method,
     ...(name === undefined ? {} : { 'Mcp-Name': name }),
   };
+}
+
+export function modernJsonRpcRequest(
+  method: string,
+  params: Record<string, unknown> = {},
+  options: {
+    id?: number;
+    clientName?: string;
+    protocolVersion?: string;
+  } = {},
+) {
+  const protocolVersion = options.protocolVersion ?? MODERN_PROTOCOL_VERSION;
+  return {
+    jsonrpc: '2.0' as const,
+    id: options.id ?? 1,
+    method,
+    params: {
+      ...params,
+      _meta: modernRequestMeta(options.clientName, protocolVersion),
+    },
+  };
+}
+
+export function mcpPostRequest(
+  body: unknown,
+  headers: Record<string, string> = {},
+): RequestInit {
+  return {
+    method: 'POST',
+    headers: {
+      accept: 'application/json, text/event-stream',
+      'content-type': 'application/json',
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+export async function readJsonRpcResponse(response: Response): Promise<Record<string, unknown>> {
+  const text = await response.text();
+  if (!response.headers.get('content-type')?.includes('text/event-stream')) {
+    return JSON.parse(text) as Record<string, unknown>;
+  }
+  const data = text.split(/\r?\n/u)
+    .find((line) => line.startsWith('data: '))
+    ?.slice('data: '.length);
+  if (data === undefined) {
+    throw new Error('MCP SSE response did not contain a data event.');
+  }
+  return JSON.parse(data) as Record<string, unknown>;
+}
+
+export async function exchangeJsonRpc(
+  body: unknown,
+  send: (init: RequestInit) => Promise<Response>,
+  headers: Record<string, string> = {},
+) {
+  const response = await send(mcpPostRequest(body, headers));
+  return {
+    response,
+    message: await readJsonRpcResponse(response),
+  };
+}
+
+export function jsonRpcResult(message: Record<string, unknown>): Record<string, unknown> {
+  const result = message.result;
+  if (typeof result !== 'object' || result === null || Array.isArray(result)) {
+    throw new Error('Expected a JSON-RPC result object.');
+  }
+  return result as Record<string, unknown>;
 }

--- a/test/support/transport-harness.ts
+++ b/test/support/transport-harness.ts
@@ -12,6 +12,14 @@ import type { CatalogMode } from '../../src/server/build-tools.js';
 import { startHttpServer } from '../../src/server/http.js';
 import { connectInMemoryClient } from '../../src/server/in-memory-client.js';
 import worker from '../../src/server/worker.js';
+import {
+  MODERN_PROTOCOL_VERSION,
+  UNSUPPORTED_MODERN_PROTOCOL_VERSION,
+  modernJsonRpcRequest,
+  modernRequestHeaders,
+  type ProtocolEra,
+  versionNegotiationForEra,
+} from './protocol-fixtures.js';
 
 export type TransportKind = 'in-memory' | 'stdio' | 'http' | 'worker';
 
@@ -23,7 +31,10 @@ export interface TransportConnection {
 
 export interface HttpFaultContract {
   malformed: { status: number; body: string };
-  invalidVersion: { status: number; body: string };
+  unsupportedVersion: { status: number; body: string };
+  bodyHeaderMismatch: { status: number; body: string };
+  missingMethodHeader: { status: number; body: string };
+  missingNameHeader: { status: number; body: string };
 }
 
 export interface LoopbackHttpServer {
@@ -51,17 +62,25 @@ export async function startLoopbackHttp(options: {
 export async function connectTransport(
   kind: TransportKind,
   mode: CatalogMode = 'full',
+  era: ProtocolEra = 'legacy',
 ): Promise<TransportConnection> {
-  const client = new Client({ name: `transport-${kind}-${mode}`, version: '0.0.0' });
+  if (kind === 'in-memory' && era === 'modern') {
+    throw new Error('The in-memory transport is a legacy-only test surface.');
+  }
 
   if (kind === 'in-memory') {
-    const connection = await connectInMemoryClient(`transport-${kind}-${mode}`, { mode });
+    const connection = await connectInMemoryClient(`transport-${kind}-${mode}-${era}`, { mode });
     return {
       client: connection.client,
       stderr: () => '',
       close: connection.close,
     };
   }
+
+  const client = new Client(
+    { name: `transport-${kind}-${mode}-${era}`, version: '0.0.0' },
+    { versionNegotiation: versionNegotiationForEra(era) },
+  );
 
   if (kind === 'stdio') {
     const transport = new StdioClientTransport({
@@ -96,8 +115,20 @@ export async function connectTransport(
       client,
       stderr: () => '',
       close: async () => {
-        await client.close();
-        await server.close();
+        const failures: unknown[] = [];
+        try {
+          await client.close();
+        } catch (error) {
+          failures.push(error);
+        }
+        try {
+          await server.close();
+        } catch (error) {
+          failures.push(error);
+        }
+        if (failures.length > 0) {
+          throw new AggregateError(failures, 'Failed to close the HTTP transport connection.');
+        }
       },
     };
   }
@@ -129,14 +160,70 @@ export async function captureHttpFaultContract(
     headers: baseHeaders,
     body: '{"private":"patient-name"',
   }));
-  const invalidVersion = await send(new Request(endpoint, {
+  const unsupportedVersion = await send(new Request(endpoint, {
     method: 'POST',
-    headers: { ...baseHeaders, 'mcp-protocol-version': '1900-01-01' },
-    body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }),
+    headers: {
+      ...baseHeaders,
+      ...modernRequestHeaders(
+        'tools/list',
+        undefined,
+        UNSUPPORTED_MODERN_PROTOCOL_VERSION,
+      ),
+    },
+    body: JSON.stringify(modernJsonRpcRequest('tools/list', {}, {
+      id: 2,
+      protocolVersion: UNSUPPORTED_MODERN_PROTOCOL_VERSION,
+    })),
+  }));
+  const bodyHeaderMismatch = await send(new Request(endpoint, {
+    method: 'POST',
+    headers: {
+      ...baseHeaders,
+      ...modernRequestHeaders(
+        'tools/list',
+        undefined,
+        UNSUPPORTED_MODERN_PROTOCOL_VERSION,
+      ),
+    },
+    body: JSON.stringify(modernJsonRpcRequest('tools/list', {}, { id: 3 })),
+  }));
+  const missingMethodHeader = await send(new Request(endpoint, {
+    method: 'POST',
+    headers: {
+      ...baseHeaders,
+      'MCP-Protocol-Version': MODERN_PROTOCOL_VERSION,
+    },
+    body: JSON.stringify(modernJsonRpcRequest('tools/list', {}, { id: 4 })),
+  }));
+  const missingNameHeader = await send(new Request(endpoint, {
+    method: 'POST',
+    headers: {
+      ...baseHeaders,
+      ...modernRequestHeaders('tools/call'),
+    },
+    body: JSON.stringify(modernJsonRpcRequest('tools/call', {
+      name: 'calculate_bmi',
+      arguments: { weight_kg: 70, height_cm: 170 },
+    }, { id: 5 })),
   }));
   return {
     malformed: { status: malformed.status, body: await malformed.text() },
-    invalidVersion: { status: invalidVersion.status, body: await invalidVersion.text() },
+    unsupportedVersion: {
+      status: unsupportedVersion.status,
+      body: await unsupportedVersion.text(),
+    },
+    bodyHeaderMismatch: {
+      status: bodyHeaderMismatch.status,
+      body: await bodyHeaderMismatch.text(),
+    },
+    missingMethodHeader: {
+      status: missingMethodHeader.status,
+      body: await missingMethodHeader.text(),
+    },
+    missingNameHeader: {
+      status: missingNameHeader.status,
+      body: await missingNameHeader.text(),
+    },
   };
 }
 
@@ -236,6 +323,7 @@ export async function captureTransportContract(
   }));
 
   return {
+    protocolEra: client.getProtocolEra(),
     serverVersion: client.getServerVersion(),
     capabilities: client.getServerCapabilities(),
     instructions: client.getInstructions(),

--- a/test/support/transport-harness.ts
+++ b/test/support/transport-harness.ts
@@ -3,12 +3,11 @@ import type { AddressInfo } from 'node:net';
 import { once } from 'node:events';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import {
   getDefaultEnvironment,
   StdioClientTransport,
-} from '@modelcontextprotocol/sdk/client/stdio.js';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+} from '@modelcontextprotocol/client/stdio';
 import type { CatalogMode } from '../../src/server/build-tools.js';
 import { startHttpServer } from '../../src/server/http.js';
 import { connectInMemoryClient } from '../../src/server/in-memory-client.js';

--- a/test/support/transport-harness.ts
+++ b/test/support/transport-harness.ts
@@ -38,17 +38,13 @@ export async function startLoopbackHttp(options: {
   mode?: CatalogMode;
   allowedOrigins?: ReadonlySet<string>;
 } = {}): Promise<LoopbackHttpServer> {
-  const server = startHttpServer({ port: 0, host: '127.0.0.1', ...options });
-  await once(server, 'listening');
-  const { port } = server.address() as AddressInfo;
+  const running = startHttpServer({ port: 0, host: '127.0.0.1', ...options });
+  await once(running.server, 'listening');
+  const { port } = running.server.address() as AddressInfo;
   return {
-    server,
+    server: running.server,
     url: new URL(`http://127.0.0.1:${port}/mcp`),
-    close: async () => {
-      if (!server.listening) return;
-      server.close();
-      await once(server, 'close');
-    },
+    close: running.close,
   };
 }
 

--- a/test/transport/http.e2e.test.ts
+++ b/test/transport/http.e2e.test.ts
@@ -8,9 +8,11 @@ import {
 const servers: LoopbackHttpServer[] = [];
 
 afterEach(async () => {
-  await Promise.allSettled(servers.splice(0).map(async (server) => {
-    await server.close();
-  }));
+  const results = await Promise.allSettled(servers.splice(0).map((server) => server.close()));
+  const failures = results.flatMap((result) => result.status === 'rejected' ? [result.reason] : []);
+  if (failures.length > 0) {
+    throw new AggregateError(failures, 'Failed to close loopback HTTP servers.');
+  }
 });
 
 async function url(): Promise<string> {
@@ -27,7 +29,17 @@ describe('loopback HTTP protocol faults', () => {
     expect(JSON.parse(contract.malformed.body)).toEqual({
       jsonrpc: '2.0', error: { code: -32700, message: 'Parse error' }, id: null,
     });
-    expect(contract.invalidVersion.status).toBe(400);
-    expect(contract.invalidVersion.body).toMatch(/Unsupported protocol version/i);
+    expect(contract.unsupportedVersion.status).toBe(400);
+    expect(JSON.parse(contract.unsupportedVersion.body)).toMatchObject({
+      error: { code: -32022, message: expect.stringMatching(/Unsupported protocol version/i) },
+    });
+    expect(contract.bodyHeaderMismatch.status).toBe(400);
+    expect(JSON.parse(contract.bodyHeaderMismatch.body)).toMatchObject({
+      error: { code: -32020, message: expect.stringMatching(/headers and body disagree/i) },
+    });
+    for (const missing of [contract.missingMethodHeader, contract.missingNameHeader]) {
+      expect(missing.status).toBe(400);
+      expect(JSON.parse(missing.body)).toMatchObject({ error: { code: -32020 } });
+    }
   });
 });

--- a/test/transport/parity.e2e.test.ts
+++ b/test/transport/parity.e2e.test.ts
@@ -5,47 +5,77 @@ import {
   connectTransport,
   type TransportKind,
 } from '../support/transport-harness.js';
+import type { ProtocolEra } from '../support/protocol-fixtures.js';
 
-const TRANSPORTS: TransportKind[] = ['in-memory', 'stdio', 'http', 'worker'];
 const MODES = ['full', 'compact'] satisfies CatalogMode[];
+const MATRIX = [
+  { era: 'legacy', kind: 'in-memory' },
+  { era: 'legacy', kind: 'stdio' },
+  { era: 'legacy', kind: 'http' },
+  { era: 'legacy', kind: 'worker' },
+  { era: 'modern', kind: 'stdio' },
+  { era: 'modern', kind: 'http' },
+  { era: 'modern', kind: 'worker' },
+] satisfies { era: ProtocolEra; kind: TransportKind }[];
+
+function keyOf(entry: (typeof MATRIX)[number]): string {
+  return `${entry.era}:${entry.kind}`;
+}
+
+function applicationContract(snapshot: Record<string, unknown>): Record<string, unknown> {
+  const contract = { ...snapshot };
+  delete contract.protocolEra;
+  return contract;
+}
 
 describe('real MCP transport parity', () => {
-  it('returns identical transport contracts and direct/compact clinical payloads', async () => {
-    const modeEntries = await Promise.all(MODES.map(async (mode) => {
-      const entries = await Promise.all(TRANSPORTS.map(async (kind) => {
-        const connection = await connectTransport(kind, mode);
-        let snapshot: Record<string, unknown>;
+  it('rejects an impossible modern in-memory test connection', async () => {
+    await expect(connectTransport('in-memory', 'full', 'modern'))
+      .rejects.toThrow('legacy-only test surface');
+  });
+
+  it('runs the full/compact legacy+modern transport matrix sequentially', async () => {
+    const byMode = new Map<CatalogMode, Map<string, Record<string, unknown>>>();
+
+    for (const mode of MODES) {
+      const snapshots = new Map<string, Record<string, unknown>>();
+      for (const entry of MATRIX) {
+        const label = `${mode} ${keyOf(entry)}`;
+        const connection = await connectTransport(entry.kind, mode, entry.era);
         try {
-          snapshot = await captureTransportContract(connection.client, mode);
+          const snapshot = await captureTransportContract(connection.client, mode);
+          expect(snapshot.protocolEra, `${label} negotiated era`).toBe(entry.era);
+          snapshots.set(keyOf(entry), snapshot);
         } finally {
           await connection.close();
         }
-        expect(connection.stderr(), `${kind} stderr`).not.toMatch(/patient|input|error/i);
-        return [kind, snapshot] as const;
-      }));
-      const snapshots = Object.fromEntries(entries) as Record<
-        TransportKind,
-        Record<string, unknown>
-      >;
-
-      for (const kind of TRANSPORTS.slice(1)) {
-        expect(snapshots[kind], `${kind} differs from in-memory`).toEqual(snapshots['in-memory']);
+        expect(connection.stderr(), `${label} stderr`).not.toMatch(/patient|input|error/i);
       }
-      return [mode, snapshots] as const;
-    }));
-    const byMode = Object.fromEntries(modeEntries) as Record<
-      CatalogMode,
-      Record<TransportKind, Record<string, unknown>>
-    >;
+      const baseline = snapshots.get('legacy:in-memory');
+      expect(baseline, `${mode} baseline`).toBeDefined();
+      for (const entry of MATRIX.slice(1)) {
+        const snapshot = snapshots.get(keyOf(entry));
+        expect(
+          applicationContract(snapshot ?? {}),
+          `${mode} ${keyOf(entry)} differs from legacy:in-memory`,
+        ).toEqual(applicationContract(baseline ?? {}));
+      }
+      byMode.set(mode, snapshots);
+    }
 
-    for (const kind of TRANSPORTS) {
-      const full = byMode.full[kind].sentinelResults as Record<string, unknown>;
-      const compact = byMode.compact[kind].sentinelResults as Record<
-        string,
-        { result: { result: unknown } }
-      >;
-      for (const [id, clinicalResult] of Object.entries(full)) {
-        expect(compact[id]?.result.result, `${kind} ${id} direct/compact`).toEqual(clinicalResult);
+    for (const entry of MATRIX) {
+      const label = keyOf(entry);
+      const full = byMode.get('full')?.get(label)?.sentinelResults as
+        | Record<string, unknown>
+        | undefined;
+      const compact = byMode.get('compact')?.get(label)?.sentinelResults as
+        | Record<string, { result: { result: unknown } }>
+        | undefined;
+      expect(full, `${label} full sentinels`).toBeDefined();
+      expect(compact, `${label} compact sentinels`).toBeDefined();
+      for (const [id, clinicalResult] of Object.entries(full ?? {})) {
+        expect(compact?.[id]?.result.result, `${label} ${id} direct/compact`)
+          .toEqual(clinicalResult);
       }
     }
   }, 120_000);

--- a/test/transport/stdio.e2e.test.ts
+++ b/test/transport/stdio.e2e.test.ts
@@ -1,27 +1,72 @@
 import { spawn } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/client';
+import {
+  getDefaultEnvironment,
+  StdioClientTransport,
+} from '@modelcontextprotocol/client/stdio';
 import { afterEach, describe, expect, it } from 'vitest';
+import {
+  LEGACY_PROTOCOL_VERSION,
+  MODERN_PROTOCOL_VERSION,
+} from '../support/protocol-fixtures.js';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '../..');
-const LEGACY_PROTOCOL_VERSION = '2025-11-25';
-const children: ReturnType<typeof spawn>[] = [];
+interface TrackedChild {
+  child: ReturnType<typeof spawn>;
+  closed: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
+}
 
-afterEach(() => {
-  for (const child of children.splice(0)) child.kill();
+const children: TrackedChild[] = [];
+
+afterEach(async () => {
+  await Promise.all(children.splice(0).map(async ({ child, closed }) => {
+    if (child.exitCode === null && child.signalCode === null) child.kill();
+    await closed;
+  }));
 });
 
 describe('spawned stdio framing', () => {
+  it('serves a modern discovery and tools list through the shared stdio entry', async () => {
+    const client = new Client(
+      { name: 'stdio-modern-smoke', version: '0.0.0' },
+      { versionNegotiation: { mode: { pin: MODERN_PROTOCOL_VERSION } } },
+    );
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: ['dist/server/stdio.js'],
+      cwd: ROOT,
+      env: getDefaultEnvironment(),
+      stderr: 'pipe',
+    });
+    let stderr = '';
+    transport.stderr?.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+
+    try {
+      await client.connect(transport);
+      expect(client.getProtocolEra()).toBe('modern');
+      expect(client.getDiscoverResult()).toBeDefined();
+      const { tools } = await client.listTools();
+      expect(tools.map(({ name }) => name)).toContain('calculate_bmi');
+      expect(stderr).toBe('');
+    } finally {
+      await client.close();
+    }
+  });
+
   it('keeps stdout JSON-RPC-only and recovers after a malformed input frame', async () => {
     const child = spawn(process.execPath, ['dist/server/stdio.js'], {
       cwd: ROOT,
       env: process.env,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
-    children.push(child);
     const closed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
       child.once('close', (code, signal) => resolve({ code, signal }));
     });
+    children.push({ child, closed });
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
     const stdoutLines: string[] = [];

--- a/test/transport/stdio.e2e.test.ts
+++ b/test/transport/stdio.e2e.test.ts
@@ -1,21 +1,32 @@
 import { spawn } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { Client } from '@modelcontextprotocol/client';
-import {
-  getDefaultEnvironment,
-  StdioClientTransport,
-} from '@modelcontextprotocol/client/stdio';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   LEGACY_PROTOCOL_VERSION,
   MODERN_PROTOCOL_VERSION,
+  jsonRpcResult,
+  modernJsonRpcRequest,
 } from '../support/protocol-fixtures.js';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '../..');
+
+interface ClosedChild {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}
+
 interface TrackedChild {
   child: ReturnType<typeof spawn>;
-  closed: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
+  closed: Promise<ClosedChild>;
+}
+
+interface RawStdioConnection {
+  stdoutLines: string[];
+  stderr(): string;
+  request(message: Record<string, unknown>): Promise<Record<string, unknown>>;
+  send(message: Record<string, unknown> | string): void;
+  end(): Promise<ClosedChild>;
 }
 
 const children: TrackedChild[] = [];
@@ -27,104 +38,86 @@ afterEach(async () => {
   }));
 });
 
-describe('spawned stdio framing', () => {
-  it('serves a modern discovery and tools list through the shared stdio entry', async () => {
-    const client = new Client(
-      { name: 'stdio-modern-smoke', version: '0.0.0' },
-      { versionNegotiation: { mode: { pin: MODERN_PROTOCOL_VERSION } } },
-    );
-    const transport = new StdioClientTransport({
-      command: process.execPath,
-      args: ['dist/server/stdio.js'],
-      cwd: ROOT,
-      env: getDefaultEnvironment(),
-      stderr: 'pipe',
-    });
-    let stderr = '';
-    transport.stderr?.on('data', (chunk) => {
-      stderr += String(chunk);
-    });
+function spawnRawStdio(): RawStdioConnection {
+  const child = spawn(process.execPath, ['dist/server/stdio.js'], {
+    cwd: ROOT,
+    env: process.env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  const closed = new Promise<ClosedChild>((resolve) => {
+    child.once('close', (code, signal) => resolve({ code, signal }));
+  });
+  children.push({ child, closed });
 
-    try {
-      await client.connect(transport);
-      expect(client.getProtocolEra()).toBe('modern');
-      expect(client.getDiscoverResult()).toBeDefined();
-      const { tools } = await client.listTools();
-      expect(tools.map(({ name }) => name)).toContain('calculate_bmi');
-      expect(stderr).toBe('');
-    } finally {
-      await client.close();
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  const stdoutLines: string[] = [];
+  let stdoutBuffer = '';
+  let stderr = '';
+  const waiters = new Map<number, {
+    resolve: (message: Record<string, unknown>) => void;
+    reject: (error: Error) => void;
+  }>();
+  let childFailure: Error | undefined;
+  const failPending = (error: Error) => {
+    childFailure ??= error;
+    for (const waiter of waiters.values()) waiter.reject(childFailure);
+    waiters.clear();
+  };
+
+  child.once('error', failPending);
+  child.once('exit', (code, signal) => {
+    if (waiters.size > 0) {
+      failPending(new Error(
+        `stdio server exited before completing pending requests (code=${String(code)}, signal=${String(signal)}).`,
+      ));
     }
   });
+  child.stdout.on('data', (chunk: string) => {
+    stdoutBuffer += chunk;
+    while (stdoutBuffer.includes('\n')) {
+      const newline = stdoutBuffer.indexOf('\n');
+      const line = stdoutBuffer.slice(0, newline);
+      stdoutBuffer = stdoutBuffer.slice(newline + 1);
+      if (line.length === 0) continue;
+      stdoutLines.push(line);
 
-  it('keeps stdout JSON-RPC-only and recovers after a malformed input frame', async () => {
-    const child = spawn(process.execPath, ['dist/server/stdio.js'], {
-      cwd: ROOT,
-      env: process.env,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    const closed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
-      child.once('close', (code, signal) => resolve({ code, signal }));
-    });
-    children.push({ child, closed });
-    child.stdout.setEncoding('utf8');
-    child.stderr.setEncoding('utf8');
-    const stdoutLines: string[] = [];
-    let stdoutBuffer = '';
-    let stderr = '';
-    const waiters = new Map<number, {
-      resolve: (message: Record<string, unknown>) => void;
-      reject: (error: Error) => void;
-    }>();
-    let childFailure: Error | undefined;
-    const failPending = (error: Error) => {
-      childFailure ??= error;
-      for (const waiter of waiters.values()) waiter.reject(childFailure);
-      waiters.clear();
-    };
-    child.once('error', failPending);
-    child.once('exit', (code, signal) => {
-      if (waiters.size > 0) {
-        failPending(new Error(`stdio server exited before completing pending requests (code=${String(code)}, signal=${String(signal)}).`));
+      let message: Record<string, unknown>;
+      try {
+        message = JSON.parse(line) as Record<string, unknown>;
+      } catch (error) {
+        failPending(new Error(`stdio server emitted non-JSON output: ${String(error)}`));
+        continue;
       }
-    });
-    child.stdout.on('data', (chunk: string) => {
-      stdoutBuffer += chunk;
-      while (stdoutBuffer.includes('\n')) {
-        const newline = stdoutBuffer.indexOf('\n');
-        const line = stdoutBuffer.slice(0, newline);
-        stdoutBuffer = stdoutBuffer.slice(newline + 1);
-        if (line.length === 0) continue;
-        stdoutLines.push(line);
-        let message: Record<string, unknown>;
-        try {
-          message = JSON.parse(line) as Record<string, unknown>;
-        } catch (error) {
-          failPending(new Error(`stdio server emitted non-JSON output: ${String(error)}`));
-          continue;
-        }
-        if (message.jsonrpc !== '2.0') {
-          failPending(new Error('stdio server emitted JSON that is not a JSON-RPC 2.0 message.'));
-          continue;
-        }
-        if (typeof message.id === 'number') {
-          const waiter = waiters.get(message.id);
-          if (waiter !== undefined) {
-            waiters.delete(message.id);
-            waiter.resolve(message);
-          } else {
-            failPending(new Error(`stdio server emitted an unexpected response ID: ${message.id}.`));
-          }
-        } else if (typeof message.method !== 'string') {
-          failPending(new Error('stdio server emitted a JSON-RPC message without a numeric ID or method.'));
-        }
+      if (message.jsonrpc !== '2.0') {
+        failPending(new Error('stdio server emitted JSON that is not a JSON-RPC 2.0 message.'));
+        continue;
       }
-    });
-    child.stderr.on('data', (chunk: string) => {
-      stderr += chunk;
-    });
+      if (typeof message.id === 'number') {
+        const waiter = waiters.get(message.id);
+        if (waiter === undefined) {
+          failPending(new Error(`stdio server emitted an unexpected response ID: ${message.id}.`));
+        } else {
+          waiters.delete(message.id);
+          waiter.resolve(message);
+        }
+      } else if (message.id !== null && typeof message.method !== 'string') {
+        failPending(new Error('stdio server emitted JSON-RPC without an ID or method.'));
+      }
+    }
+  });
+  child.stderr.on('data', (chunk: string) => {
+    stderr += chunk;
+  });
 
-    const request = (message: Record<string, unknown>) => new Promise<Record<string, unknown>>((resolve, reject) => {
+  const send = (message: Record<string, unknown> | string) => {
+    const line = typeof message === 'string' ? message : JSON.stringify(message);
+    child.stdin.write(`${line}\n`, (error) => {
+      if (error) failPending(error);
+    });
+  };
+  const request = (message: Record<string, unknown>) => new Promise<Record<string, unknown>>(
+    (resolve, reject) => {
       if (childFailure !== undefined) {
         reject(childFailure);
         return;
@@ -135,33 +128,109 @@ describe('spawned stdio framing', () => {
         return;
       }
       waiters.set(id, { resolve, reject });
-      child.stdin.write(`${JSON.stringify(message)}\n`, (error) => {
-        if (error) failPending(error);
-      });
-    });
-    const initialized = await request({
+      send(message);
+    },
+  );
+
+  return {
+    stdoutLines,
+    stderr: () => stderr,
+    request,
+    send,
+    end: async () => {
+      child.stdin.end();
+      const exit = await closed;
+      if (childFailure !== undefined) throw childFailure;
+      return exit;
+    },
+  };
+}
+
+function expectJsonRpcOnly(lines: string[]): void {
+  expect(lines.length).toBeGreaterThanOrEqual(2);
+  for (const line of lines) {
+    expect(JSON.parse(line), line).toMatchObject({ jsonrpc: '2.0' });
+  }
+}
+
+function expectConservativeModernResult(result: Record<string, unknown>): void {
+  expect(result.resultType).toBe('complete');
+  expect(result.ttlMs).toBe(0);
+  expect(result.cacheScope).toBe('private');
+  expect(result._meta).toMatchObject({
+    'io.modelcontextprotocol/serverInfo': {
+      name: 'oath-mcp',
+      version: expect.any(String),
+    },
+  });
+}
+
+describe('spawned stdio framing', () => {
+  it('keeps the legacy opening exact and recovers after malformed input', async () => {
+    const connection = spawnRawStdio();
+    const initialized = await connection.request({
       jsonrpc: '2.0',
       id: 1,
       method: 'initialize',
       params: {
         protocolVersion: LEGACY_PROTOCOL_VERSION,
         capabilities: {},
-        clientInfo: { name: 'raw-stdio-test', version: '0.0.0' },
+        clientInfo: { name: 'raw-stdio-legacy', version: '0.0.0' },
       },
     });
-    expect(initialized).toHaveProperty('result');
-    child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })}\n`);
-    child.stdin.write('{malformed-json\n');
-    const listed = await request({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
-    expect(listed).toHaveProperty('result');
+    const initializeResult = jsonRpcResult(initialized);
+    expect(initializeResult.protocolVersion).toBe(LEGACY_PROTOCOL_VERSION);
+    connection.send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+    connection.send('{malformed-json');
 
-    child.stdin.end();
-    await expect(closed).resolves.toEqual({ code: 0, signal: null });
-    expect(childFailure).toBeUndefined();
-    expect(stdoutLines.length).toBeGreaterThanOrEqual(2);
-    for (const line of stdoutLines) {
-      expect(JSON.parse(line), line).toMatchObject({ jsonrpc: '2.0' });
-    }
-    expect(stderr).toBe('');
+    const listed = jsonRpcResult(await connection.request({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/list',
+      params: {},
+    }));
+    expect((listed.tools as { name: string }[]).map(({ name }) => name))
+      .toContain('calculate_bmi');
+    expect(listed).not.toHaveProperty('resultType');
+    expect(listed).not.toHaveProperty('ttlMs');
+    expect(listed).not.toHaveProperty('cacheScope');
+    expect(listed).not.toHaveProperty('_meta');
+    expect(listed).not.toHaveProperty('sessionId');
+
+    await expect(connection.end()).resolves.toEqual({ code: 0, signal: null });
+    expectJsonRpcOnly(connection.stdoutLines);
+    expect(connection.stderr()).toBe('');
+  }, 15_000);
+
+  it('opens a separate modern process with discovery and wire-only metadata', async () => {
+    const connection = spawnRawStdio();
+    const discovered = jsonRpcResult(await connection.request(modernJsonRpcRequest(
+      'server/discover',
+      {},
+      { id: 1, clientName: 'raw-stdio-modern' },
+    )));
+    expect(discovered.supportedVersions).toContain(MODERN_PROTOCOL_VERSION);
+    expect(discovered.capabilities).toMatchObject({ tools: {}, resources: {}, prompts: {} });
+    expectConservativeModernResult(discovered);
+
+    const firstList = jsonRpcResult(await connection.request(modernJsonRpcRequest(
+      'tools/list',
+      {},
+      { id: 2, clientName: 'raw-stdio-modern' },
+    )));
+    const secondList = jsonRpcResult(await connection.request(modernJsonRpcRequest(
+      'tools/list',
+      {},
+      { id: 3, clientName: 'raw-stdio-modern' },
+    )));
+    const names = (firstList.tools as { name: string }[]).map(({ name }) => name);
+    expect(names).toEqual((secondList.tools as { name: string }[]).map(({ name }) => name));
+    expect(names).toContain('calculate_bmi');
+    expectConservativeModernResult(firstList);
+    expect(firstList).not.toHaveProperty('sessionId');
+
+    await expect(connection.end()).resolves.toEqual({ code: 0, signal: null });
+    expectJsonRpcOnly(connection.stdoutLines);
+    expect(connection.stderr()).toBe('');
   }, 15_000);
 });

--- a/test/transport/stdio.e2e.test.ts
+++ b/test/transport/stdio.e2e.test.ts
@@ -1,10 +1,10 @@
 import { spawn } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
 import { afterEach, describe, expect, it } from 'vitest';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '../..');
+const LEGACY_PROTOCOL_VERSION = '2025-11-25';
 const children: ReturnType<typeof spawn>[] = [];
 
 afterEach(() => {
@@ -99,7 +99,7 @@ describe('spawned stdio framing', () => {
       id: 1,
       method: 'initialize',
       params: {
-        protocolVersion: LATEST_PROTOCOL_VERSION,
+        protocolVersion: LEGACY_PROTOCOL_VERSION,
         capabilities: {},
         clientInfo: { name: 'raw-stdio-test', version: '0.0.0' },
       },

--- a/test/transport/worker-workerd.e2e.test.ts
+++ b/test/transport/worker-workerd.e2e.test.ts
@@ -1,0 +1,112 @@
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import { createTestHarness } from 'wrangler';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  type ProtocolEra,
+  versionNegotiationForEra,
+} from '../support/protocol-fixtures.js';
+import { captureTransportContract } from '../support/transport-harness.js';
+
+const harness = createTestHarness({
+  workers: [{ configPath: './wrangler.jsonc' }],
+});
+
+beforeAll(async () => {
+  await harness.listen();
+});
+
+afterAll(async () => {
+  await harness.close();
+});
+
+async function connectWorkerd(era: ProtocolEra): Promise<Client> {
+  const client = new Client(
+    { name: `workerd-${era}`, version: '0.0.0' },
+    { versionNegotiation: versionNegotiationForEra(era) },
+  );
+  const worker = harness.getWorker();
+  const transport = new StreamableHTTPClientTransport(
+    new URL('https://worker.example/mcp'),
+    {
+      fetch: async (input, init) => {
+        const body = init?.body;
+        if (body !== undefined && body !== null && typeof body !== 'string') {
+          throw new TypeError('The MCP workerd test transport expects a JSON string body.');
+        }
+        const response = await worker.fetch(input.toString(), {
+          method: init?.method,
+          headers: init?.headers === undefined
+            ? undefined
+            : Object.fromEntries(new Headers(init.headers).entries()),
+          body: body ?? undefined,
+        });
+        return response as unknown as Response;
+      },
+    },
+  );
+  await client.connect(transport);
+  return client;
+}
+
+async function callCompact(
+  client: Client,
+  id: string,
+  inputs: Record<string, unknown>,
+): Promise<void> {
+  const result = await client.callTool({
+    name: 'calculate',
+    arguments: { id, inputs },
+  });
+  expect(result.isError, id).not.toBe(true);
+  expect(result.structuredContent, id).toMatchObject({
+    result: {
+      calculator: id,
+      ok: true,
+      result: { id, evidenceUri: `calc://${id}/evidence` },
+    },
+  });
+}
+
+describe('real workerd compact transport', () => {
+  it('serves representative calculations and concurrency in both eras', async () => {
+    for (const era of ['legacy', 'modern'] satisfies ProtocolEra[]) {
+      const client = await connectWorkerd(era);
+      try {
+        const contract = await captureTransportContract(client, 'compact');
+        expect(contract.protocolEra, era).toBe(era);
+        expect([...(contract.tools as string[])].sort(), era).toEqual([
+          'calculate',
+          'calculate_panel',
+          'describe_calculator',
+          'find_calculator',
+        ]);
+        expect(contract.resources as string[], era).toContain('calc://bmi/evidence');
+        expect([...(contract.prompts as string[])].sort(), era).toEqual([
+          'interpret_abg',
+          'interpret_csf',
+          'interpret_hepb',
+        ]);
+        expect(contract.sentinelResults as Record<string, unknown>, era).toMatchObject({
+          bmi: expect.any(Object),
+          qsofa: expect.any(Object),
+          meld: expect.any(Object),
+          hepb: expect.any(Object),
+        });
+        expect(contract.concurrent as unknown[], era).toHaveLength(3);
+
+        await callCompact(client, 'meld', {
+          creatinine: { value: 176.8, unit: 'umol/L' },
+          bilirubin: { value: 34.2, unit: 'umol/L' },
+          inr: 1.5,
+          sodium: { value: 135, unit: 'mmol/L' },
+          albumin: { value: 30, unit: 'g/L' },
+          age_at_registration: 40,
+          sex: 'male',
+          dialysis: false,
+        });
+      } finally {
+        await client.close();
+      }
+    }
+  }, 120_000);
+});

--- a/test/transport/worker.e2e.test.ts
+++ b/test/transport/worker.e2e.test.ts
@@ -9,7 +9,17 @@ describe('Worker protocol faults', () => {
     expect(contract.malformed.status).toBe(400);
     expect(contract.malformed.body).toMatch(/Parse error/i);
     expect(contract.malformed.body).not.toContain('patient-name');
-    expect(contract.invalidVersion.status).toBe(400);
-    expect(contract.invalidVersion.body).toMatch(/Unsupported protocol version/i);
+    expect(contract.unsupportedVersion.status).toBe(400);
+    expect(JSON.parse(contract.unsupportedVersion.body)).toMatchObject({
+      error: { code: -32022, message: expect.stringMatching(/Unsupported protocol version/i) },
+    });
+    expect(contract.bodyHeaderMismatch.status).toBe(400);
+    expect(JSON.parse(contract.bodyHeaderMismatch.body)).toMatchObject({
+      error: { code: -32020, message: expect.stringMatching(/headers and body disagree/i) },
+    });
+    for (const missing of [contract.missingMethodHeader, contract.missingNameHeader]) {
+      expect(missing.status).toBe(400);
+      expect(JSON.parse(missing.body)).toMatchObject({ error: { code: -32020 } });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- migrate the MCP boundary to the split TypeScript SDK v2 packages
- serve modern MCP 2026-07-28 and legacy clients through one compatibility path
- preserve the compact four-tool hosted surface and the full self-hosted surface
- document the compatibility and release verification contract

## Verification

- `npm run check`
- `npm run check:worker`
- `npm --prefix docs-site run check`
- modern and explicit-legacy HTTP, stdio, and workerd transport coverage
- production verifier pins the modern protocol and retains a bounded legacy smoke test

## Deployment

This pull request does not deploy production. The hosted endpoint remains on 0.1.0 until the separately prepared 0.2.0 tagged release completes its production gates.
