### PR TITLE
ci: make Worker releases rollback-safe

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -7,7 +7,7 @@ on:
       - "v*"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: oathmcp-production-release
   cancel-in-progress: false
 
 permissions:
@@ -42,13 +42,16 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: validate-release
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 45
     environment:
       name: production
       url: https://mcp.oath.md
     outputs:
-      mcp_version_id: ${{ steps.deploy_mcp.outputs.version_id }}
-      docs_version_id: ${{ steps.deploy_docs.outputs.version_id }}
+      mcp_version_id: ${{ steps.cutover.outputs.mcp_version_id }}
+      docs_version_id: ${{ steps.cutover.outputs.docs_version_id }}
+      previous_mcp_version_id: ${{ steps.cutover.outputs.previous_mcp_version_id }}
+      previous_docs_version_id: ${{ steps.cutover.outputs.previous_docs_version_id }}
+      previous_version: ${{ steps.cutover.outputs.previous_version }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -64,8 +67,8 @@ jobs:
       - run: npm --prefix docs-site ci
       - run: npm run build
       - run: npm --prefix docs-site run build
-      - name: Deploy exact tagged MCP Worker
-        id: deploy_mcp
+      - name: Upload, cut over, verify, and roll back on failure
+        id: cutover
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -73,46 +76,11 @@ jobs:
         run: |
           test -n "$CLOUDFLARE_API_TOKEN"
           test -n "$CLOUDFLARE_ACCOUNT_ID"
-          deploy_output="$(npx wrangler deploy --tag "$GITHUB_REF_NAME" --message "OathMCP $GITHUB_REF_NAME ($GITHUB_SHA)" 2>&1)"
-          printf '%s\n' "$deploy_output"
-          version_id="$(printf '%s\n' "$deploy_output" | sed -n 's/.*Current Version ID: //p' | tr -d '\r' | tail -n 1)"
-          test -n "$version_id"
-          echo "version_id=$version_id" >> "$GITHUB_OUTPUT"
-      - name: Deploy exact tagged Blume docs Worker
-        id: deploy_docs
-        working-directory: docs-site
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          NO_COLOR: "1"
-        run: |
-          test -n "$CLOUDFLARE_API_TOKEN"
-          test -n "$CLOUDFLARE_ACCOUNT_ID"
-          deploy_output="$(npx wrangler deploy --tag "$GITHUB_REF_NAME" --message "OathMCP Blume docs $GITHUB_REF_NAME ($GITHUB_SHA)" 2>&1)"
-          printf '%s\n' "$deploy_output"
-          version_id="$(printf '%s\n' "$deploy_output" | sed -n 's/.*Current Version ID: //p' | tr -d '\r' | tail -n 1)"
-          test -n "$version_id"
-          echo "version_id=$version_id" >> "$GITHUB_OUTPUT"
-
-  verify-production:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: deploy-production
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
-        with:
-          node-version: 22
-          cache: npm
-      - run: npm ci
-      - run: npm run verify:production
+          npm run deploy:production -- --tag "$GITHUB_REF_NAME" --sha "$GITHUB_SHA"
 
   publish-npm:
     if: startsWith(github.ref, 'refs/tags/v') && vars.NPM_PUBLISH_ENABLED == 'true'
-    needs: verify-production
+    needs: deploy-production
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: production
@@ -145,11 +113,10 @@ jobs:
     if: >-
       always() &&
       startsWith(github.ref, 'refs/tags/v') &&
-      needs.verify-production.result == 'success' &&
+      needs.deploy-production.result == 'success' &&
       (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped')
     needs:
       - deploy-production
-      - verify-production
       - publish-npm
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -170,13 +137,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           MCP_VERSION_ID: ${{ needs.deploy-production.outputs.mcp_version_id }}
           DOCS_VERSION_ID: ${{ needs.deploy-production.outputs.docs_version_id }}
+          PREVIOUS_MCP_VERSION_ID: ${{ needs.deploy-production.outputs.previous_mcp_version_id }}
+          PREVIOUS_DOCS_VERSION_ID: ${{ needs.deploy-production.outputs.previous_docs_version_id }}
+          PREVIOUS_VERSION: ${{ needs.deploy-production.outputs.previous_version }}
         run: |
           notes="$(printf '%s\n' \
             "Production deployment verified from commit \`$GITHUB_SHA\`." \
             "" \
             "- MCP Worker version: \`$MCP_VERSION_ID\`" \
             "- Blume docs Worker version: \`$DOCS_VERSION_ID\`" \
-            "- Live MCP catalog, new-calculator calculation, and every generated calculator page passed.")"
+            "- Rollback baseline: OathMCP \`$PREVIOUS_VERSION\`, MCP \`$PREVIOUS_MCP_VERSION_ID\`, docs \`$PREVIOUS_DOCS_VERSION_ID\`" \
+            "- Modern and legacy MCP clients, the complete catalog, newly released calculator cases, and every generated calculator page passed.")"
           gh release create "$GITHUB_REF_NAME" release-artifacts/*.tgz \
             --verify-tag \
             --generate-notes \

--- a/README.md
+++ b/README.md
@@ -143,14 +143,15 @@ Deploy to Workers only after reviewing [Responsible Use](docs/RESPONSIBLE_USE.md
 the security and privacy boundary, and the release checklist. The official
 MCP and Blume Workers deploy from one exact `v*` tag only after
 `npm run check:release` passes; the workflow then verifies the live catalog,
-new-calculator execution, and every generated calculator page before creating
-the GitHub release. For a manual recovery deployment:
+modern and legacy clients, new-calculator execution, and every generated
+calculator page before creating the GitHub release. For a manual recovery
+deployment from an exact release tag:
 
 ```bash
 npm run check:release
-npm run deploy:worker
-npm --prefix docs-site run deploy
-npm run verify:production
+npm run deploy:production -- \
+  --tag "$(git describe --tags --exact-match)" \
+  --sha "$(git rev-parse HEAD)"
 ```
 
 The official documentation is available at `https://mcp.oath.md/docs/`, and the

--- a/docs-site/AGENTS.md
+++ b/docs-site/AGENTS.md
@@ -35,6 +35,6 @@ Blume build.
 
 Calculator pull requests must run the generator and commit the resulting page.
 Production deployment belongs to the root tag-driven release workflow, which
-deploys the MCP Worker first, deploys this site from the same tag second, and
-then verifies both live surfaces. A merge to `main` is not a documentation
-deployment.
+uploads both versions before changing traffic, promotes this site and then the
+MCP Worker directly to 100%, and verifies both live surfaces. A merge to `main`
+is not a documentation deployment.

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -86,15 +86,14 @@ HTTPS URL before delegating to the static-assets binding. It also applies HSTS
 and `nosniff` defensively to the returned asset response; it does not render,
 transform, log, or inspect documentation content.
 
-The tagged workflow deploys the MCP first and the docs second, then verifies the
-docs home, every generated calculator page, the attested live MCP catalog, and
-new-calculator execution. Rollback remains independent through the `oath-docs`
-Worker deployment history; removing its two routes returns those requests to
-the MCP Worker.
+The tagged workflow uploads both Worker versions without changing traffic,
+promotes docs and then MCP directly to 100%, and verifies the docs home, every
+generated calculator page, both MCP protocol eras, the attested live catalog,
+and new-calculator execution. A failed cutover automatically restores MCP first
+and docs second to their captured production version IDs.
 
-For manual recovery only, check out the exact release tag and run:
+For manual recovery only, check out the exact release tag.
 
-```bash
-npm run check
-npm run deploy
-```
+Use the repository-root deployment coordinator for manual recovery so the same
+availability probes, verification, and automatic rollback remain in force. See
+[`docs/RELEASE.md`](../docs/RELEASE.md) for the exact command.

--- a/docs-site/docs/operations/deployment.mdx
+++ b/docs-site/docs/operations/deployment.mdx
@@ -22,8 +22,10 @@ clinically changed contract under an unchanged release record.
 
 Production is deployed only by the repository's `vX.Y.Z` tag workflow. It
 validates the tagged release evidence before credentials are available, then
-deploys `oath-mcp` followed by `oath-docs`. The workflow polls the real endpoint
-and verifies both surfaces before creating a GitHub release.
+uploads both Worker versions without changing traffic. It continuously probes
+the live service while promoting `oath-docs` and then `oath-mcp` directly to
+100%; MCP traffic is never split between versions. The workflow verifies both
+surfaces before creating a GitHub release.
 
 The protected GitHub `production` environment holds the least-privilege
 Cloudflare token and account identifier. The former continuous deployment from
@@ -31,9 +33,9 @@ the `main` branch must remain disconnected so there is only one production
 owner and an accepted-but-unreleased calculator cannot appear on one surface
 without the other.
 
-Direct Wrangler deployment is reserved for recorded recovery. If one Worker
-changes and the following deployment or verification fails, restore the
-changed Worker to its immediately prior verified version and rerun the live
-verification. See the repository
+Recorded recovery uses the same tested deployment coordinator. A failed or
+partial cutover automatically restores the captured MCP version first and docs
+version second, then confirms the previous health version, legacy BMI, and docs
+root. See the repository
 [release guide](https://github.com/OATH-md/OathMCP/blob/main/docs/RELEASE.md)
 for the exact commands.

--- a/docs-site/docs/operations/release-and-versioning.mdx
+++ b/docs-site/docs/operations/release-and-versioning.mdx
@@ -32,11 +32,17 @@ release attestations are not rewritten.
 The tag-triggered workflow:
 
 1. runs the complete release gate;
-2. deploys the MCP Worker;
-3. deploys the Blume Worker from the same tag;
-4. verifies the live version, catalog, evidence resources, newly added
+2. captures the live rollback baseline and uploads both Worker versions without
+   changing traffic;
+3. promotes the Blume Worker and then the MCP Worker directly to 100% while
+   continuously probing both surfaces;
+4. verifies the live version, catalog, evidence resources, BMI, a panel, newly added
    calculator cases, and every generated calculator page; and
 5. creates the GitHub release only after production verification succeeds.
+
+Any partial deployment or failed verification automatically restores the prior
+MCP version first and the prior docs version second. Percentage-based canaries
+are not used because one MCP exchange must not be split across server versions.
 
 The exact maintainer commands, required GitHub environment, recovery path, and
 current release state are maintained in the repository

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -9,7 +9,6 @@
   "scripts": {
     "dev": "npm run generate && blume dev",
     "build": "blume build && node scripts/stage-cloudflare.mjs",
-    "deploy": "npm run check && wrangler deploy",
     "preview": "blume preview",
     "generate": "node scripts/generate-from-repo.mjs",
     "generate:calculators": "node scripts/generate-calculators.mjs",

--- a/docs/HOSTING.md
+++ b/docs/HOSTING.md
@@ -96,17 +96,23 @@ package-version clinical attestation, the complete Blume site, and the package
 tarball. Only then can the protected `production` environment expose its
 least-privilege Cloudflare credential.
 
-The workflow builds both Worker artifacts before changing production, then
-deploys `oath-mcp` followed by `oath-docs` from the same tagged checkout under
-one protected-environment approval. Its production verifier polls `/health`,
-compares the complete live evidence-resource catalog with the release
-attestation, describes every calculator, calculates a source-linked case for
-each newly released calculator, and verifies every generated Blume page. The
-GitHub release is created only after those live checks pass.
+The workflow builds and uploads both Worker versions before changing production
+traffic. It records the two current version IDs and the live `/health` version,
+starts continuous availability probes, promotes `oath-docs` directly to 100%,
+and then promotes `oath-mcp` directly to 100%. It never splits MCP traffic
+between versions.
 
-Cloudflare Workers Builds must be disconnected from `main` after the tagged
-workflow is configured. There must not be a second production path whose source
-and release state differ from the tag.
+The production verifier opens a modern-pinned MCP client, compares the complete
+live evidence-resource catalog with the release attestation, describes every
+calculator, exercises discovery, BMI, a panel, and each newly released
+calculator, and then runs a separate explicit-legacy smoke. It also verifies
+every generated Blume page. Any cutover or verification failure automatically
+rolls back MCP first and docs second to the captured version IDs, confirms the
+previous health version, legacy BMI, and docs root, and fails the workflow. The
+GitHub release is created only after the full cutover succeeds.
+
+Cloudflare Workers Builds must remain disconnected from `main`. There must not
+be a second production path whose source and release state differ from the tag.
 
 For OpenAI plugin-domain verification, obtain the exact token from the plugin
 submission portal and install it without committing it:
@@ -133,16 +139,16 @@ exact release tag, then run:
 npm ci
 npm --prefix docs-site ci
 npm run check:release
-npm run deploy:worker
-npm --prefix docs-site run deploy
-npm run verify:production
+npm run deploy:production -- \
+  --tag "$(git describe --tags --exact-match)" \
+  --sha "$(git rev-parse HEAD)"
 ```
 
-The production verifier covers version, catalog, description, newly released
-calculation, evidence, and Blume-page parity. Also confirm that a disallowed
-browser origin receives 403, plaintext HTTP redirects with 308, HTTPS carries
-the HSTS header, a JSON-RPC batch receives 400/`-32600`, and no request body
-appears in Workers Logs.
+The coordinator performs the same upload-first cutover, continuous probes,
+production verification, and automatic rollback as the tagged workflow. Also
+confirm that a disallowed browser origin receives 403, plaintext HTTP redirects
+with 308, HTTPS carries the HSTS header, a JSON-RPC batch receives
+400/`-32600`, and no request body appears in Workers Logs.
 
 Record the deployed package version, Worker deployment or version identifier,
 UTC timestamp, commit, verification result, and previous deployable version in
@@ -150,12 +156,24 @@ the release notes or deployment record before announcing availability.
 
 ## Rollback
 
-Use Cloudflare Workers deployment history to roll back to the immediately prior
-verified deployment. After rollback, repeat the remote transport checks and
-confirm `/health` reports the expected package version. If a safe deployment is
-not available, remove the `mcp.oath.md` custom domain or disable the Worker until
-the issue is resolved. Do not silently serve a clinically changed contract under
-the same recorded release state.
+The deployment coordinator automatically rolls back a partial or failed
+cutover. It restores `oath-mcp` first and `oath-docs` second, confirms both
+captured version IDs are again receiving 100% of traffic, and then verifies the
+previous `/health` version, a legacy BMI calculation, and the docs root.
+
+If manual intervention is required, use the exact captured version IDs with
+these commands, again restoring MCP before docs. Set `MCP_VERSION_ID` and
+`DOCS_VERSION_ID` to the recorded values before running them:
+
+```bash
+npx wrangler rollback "$MCP_VERSION_ID" -y
+npx wrangler --cwd docs-site rollback "$DOCS_VERSION_ID" -y
+```
+
+Keep the existing routes and domains in place so the last verified version
+remains available. Treat an incomplete rollback as an incident, do not create
+or announce the GitHub release, and do not silently serve a clinically changed
+contract under the previous release state.
 
 ## Deployment record
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -137,14 +137,17 @@ production credentials are available.
 publisher. A `v*` tag runs these ordered jobs:
 
 1. Validate the exact tag with `npm run check:release`.
-2. Build both tagged Worker artifacts before changing production.
-3. Deploy `oath-mcp` and then the tagged Blume `oath-docs` Worker under one
-   protected-environment approval.
-4. Poll the live service until `/health` reports the tagged version.
+2. Confirm both Workers have exactly one version receiving 100% of traffic and
+   capture those version IDs plus the live `/health` version.
+3. Build and upload both tagged Worker versions without changing production
+   traffic.
+4. Start continuous probes, promote `oath-docs` directly to 100%, verify it,
+   and then promote `oath-mcp` directly to 100%. Never split MCP traffic.
 5. Open a modern-pinned `2026-07-28` client and compare every live
    `calc://<id>/evidence` resource with the attested catalog.
-6. Call `describe_calculator` for every calculator and calculate a source-linked
-   reference case for every calculator newly added since the prior attestation.
+6. Call `describe_calculator` for every calculator, exercise discovery, BMI and
+   panel calculation, and calculate a source-linked reference case for every
+   calculator newly added since the prior attestation.
 7. Open a separate explicit-legacy client and require the bounded
    list/resource/calculation smoke to pass.
 8. Fetch and verify one generated Blume page for every attested calculator.
@@ -152,9 +155,13 @@ publisher. A `v*` tag runs these ordered jobs:
 10. Attach the package tarball and both Cloudflare Worker version IDs to the
    GitHub release.
 
-Any failure prevents the GitHub release. Do not announce a calculator from a
-green build alone; the terminal state is the successful production-verification
-job and resulting GitHub release.
+Any partial cutover, failed availability probe, or production-verification
+failure rolls back MCP first and docs second to the captured version IDs. The
+workflow then confirms the previous health version, a legacy BMI calculation,
+and the docs root. A failed deployment or incomplete rollback prevents the
+GitHub release. Do not announce a calculator from a green build alone; the
+terminal state is the successful protected deployment job and resulting GitHub
+release.
 
 ## One-time production configuration
 
@@ -173,11 +180,10 @@ when creating and rotating the token.
 Protect `v*` tag creation with a repository ruleset so only release maintainers
 can start production, and keep the normal required checks on `main`.
 
-Disconnect the old Cloudflare Workers Builds connection from `main` after this
-tag workflow is merged and its credentials are tested. Production must have one
-owner: the tagged GitHub workflow. Leaving the old `main` trigger connected
-creates an ambiguous second path that either fails against an unreleased
-attestation or deploys source that has not completed the release workflow.
+Keep Cloudflare Workers Builds disconnected from `main`. Production must have
+one owner: the tagged GitHub workflow. Reconnecting a `main` trigger creates an
+ambiguous second path that either fails against an unreleased attestation or
+deploys source that has not completed the release workflow.
 
 The npm job is disabled unless repository variable
 `NPM_PUBLISH_ENABLED=true`. Enable it only after the `oath-mcp` package has an
@@ -190,21 +196,23 @@ token to the repository.
 Manual dispatch of the workflow runs release validation but never deploys;
 production jobs require an actual `v*` tag.
 
-Use direct Wrangler deployment only for recovery:
+Use the tested coordinator only for recorded recovery from an exact release
+tag:
 
 ```bash
 npm ci
 npm --prefix docs-site ci
 npm run check:release
-npm run deploy:worker
-npm --prefix docs-site run deploy
-npm run verify:production
+npm run deploy:production -- \
+  --tag "$(git describe --tags --exact-match)" \
+  --sha "$(git rev-parse HEAD)"
 ```
 
-Record the reason and both resulting Worker version IDs. If the second
-deployment or live verification fails after the first Worker changes, roll the
-changed Worker back to its immediately prior verified version and repeat live
-verification. See [Hosted Endpoint Operations](HOSTING.md).
+Record the reason, captured rollback baseline, and both resulting Worker version
+IDs. The coordinator uploads before cutover and automatically restores a failed
+deployment. If rollback needs manual intervention, restore MCP first and docs
+second to the captured version IDs and repeat the bounded rollback verification.
+See [Hosted Endpoint Operations](HOSTING.md).
 
 ## npm, license, and responsibility
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "release:prepare": "tsx src/cli/index.ts prepare-release && npm --prefix docs-site run generate",
     "check:release-metadata": "node scripts/release/check-metadata.mjs",
     "check:release": "npm run check:release-metadata && npm run check && npm run check:clinical-release && npm --prefix docs-site run check && npm pack --dry-run",
+    "deploy:production": "node scripts/release/deploy-production.mjs",
     "verify:production": "node scripts/release/verify-production.mjs",
     "check:package": "vitest run test/package-manifest.test.ts",
     "check": "npm run check:generated && npm run lint:specs && npm run validate:clinical -- --require-scenario-verified && npm run typecheck && npm run build && npm run test:run && npm run check:package",
@@ -75,8 +76,7 @@
     "start:http": "node dist/server/http.js",
     "types:worker": "wrangler types src/server/worker-configuration.d.ts --strict-vars false",
     "check:worker": "npm run build && wrangler types src/server/worker-configuration.d.ts --strict-vars false --check && node scripts/check-worker-bundle.mjs",
-    "check:deploy": "npm run check:release && wrangler types src/server/worker-configuration.d.ts --strict-vars false --check && wrangler deploy --dry-run",
-    "deploy:worker": "npm run check:deploy && wrangler deploy"
+    "check:deploy": "npm run check:release && wrangler types src/server/worker-configuration.d.ts --strict-vars false --check && wrangler deploy --dry-run"
   },
   "dependencies": {
     "@modelcontextprotocol/express": "^2.0.0",

--- a/scripts/release/deploy-production.d.mts
+++ b/scripts/release/deploy-production.d.mts
@@ -1,0 +1,80 @@
+export interface WranglerResult {
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+}
+
+export interface ContinuityMonitor {
+  ready: Promise<void>;
+  failed: Promise<Error>;
+  assertHealthy(): void;
+  stop(options?: { assertHealthy?: boolean }): Promise<void>;
+}
+
+export function parseActiveVersion(
+  value: unknown,
+  label: string,
+): string;
+
+export function parseUploadedVersionId(...outputs: string[]): string;
+
+export function parseDeployArgs(argv: string[]): {
+  tag: string;
+  sha: string;
+  baseUrl: string;
+};
+
+export function runWranglerCommand(options: {
+  args: string[];
+  cwd: string;
+  quiet?: boolean;
+  env?: NodeJS.ProcessEnv;
+  spawnImpl?: typeof import('node:child_process').spawn;
+  stderr?: NodeJS.WritableStream;
+  stdout?: NodeJS.WritableStream;
+  timeoutMs?: number;
+}): Promise<WranglerResult>;
+
+export function createContinuityMonitor(options: {
+  baseUrl?: string | URL;
+  fetchImpl?: typeof fetch;
+  intervalMs?: number;
+  probe?: () => Promise<void>;
+}): ContinuityMonitor;
+
+export function readHealthVersion(
+  baseUrl: string | URL,
+  fetchImpl?: typeof fetch,
+): Promise<string>;
+
+export function deployProduction(
+  options: {
+    tag: string;
+    sha: string;
+    baseUrl?: string | URL;
+    githubOutput?: string;
+  },
+  dependencies?: {
+    runWrangler?: (options: {
+      args: string[];
+      cwd: string;
+      quiet?: boolean;
+    }) => Promise<WranglerResult>;
+    fetchImpl?: typeof fetch;
+    monitorFactory?: (options: {
+      baseUrl: string | URL;
+      fetchImpl: typeof fetch;
+    }) => ContinuityMonitor;
+    verifyProductionImpl?: (options: {
+      baseUrl: string | URL;
+      signal: AbortSignal;
+      timeoutMs: number;
+    }) => Promise<unknown>;
+    verifyRollbackImpl?: (options: {
+      baseUrl: string | URL;
+      expectedVersion: string;
+    }) => Promise<void>;
+    writeOutputs?: (path: string | undefined, values: Record<string, string>) => Promise<void>;
+    log?: (message: string) => void;
+  },
+): Promise<Record<string, string>>;

--- a/scripts/release/deploy-production.mjs
+++ b/scripts/release/deploy-production.mjs
@@ -1,0 +1,452 @@
+import { spawn } from 'node:child_process';
+import { appendFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+  verifyProduction,
+  verifyRollbackProduction,
+} from './verify-production.mjs';
+
+const root = resolve(import.meta.dirname, '../..');
+const wranglerEntrypoint = resolve(root, 'node_modules/wrangler/bin/wrangler.js');
+const workers = {
+  mcp: { cwd: root, label: 'MCP Worker' },
+  docs: { cwd: resolve(root, 'docs-site'), label: 'Blume docs Worker' },
+};
+
+function messageFrom(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function parseActiveVersion(value, label) {
+  const versions = value?.versions;
+  if (!Array.isArray(versions) || versions.length !== 1) {
+    throw new Error(`${label} must have exactly one active production version`);
+  }
+  const [active] = versions;
+  if (active?.percentage !== 100 || typeof active.version_id !== 'string' || active.version_id.length === 0) {
+    throw new Error(`${label} must route 100% of production traffic to one version`);
+  }
+  return active.version_id;
+}
+
+export function parseUploadedVersionId(...outputs) {
+  for (const output of outputs) {
+    const match = /Worker Version ID:\s*([0-9a-f-]{36})/iu.exec(output);
+    if (match) return match[1];
+  }
+  throw new Error('Wrangler upload did not report a Worker Version ID');
+}
+
+export function parseDeployArgs(argv) {
+  const options = { baseUrl: 'https://mcp.oath.md' };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--tag' || token === '--sha' || token === '--base-url') {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) throw new Error(`${token} requires a value`);
+      options[token.slice(2)] = value;
+      index += 1;
+    } else {
+      throw new Error(`Unknown option '${token}'`);
+    }
+  }
+  if (!/^v\d+\.\d+\.\d+$/u.test(options.tag ?? '')) {
+    throw new Error('--tag must be a vX.Y.Z release tag');
+  }
+  if (!/^[0-9a-f]{40}$/iu.test(options.sha ?? '')) {
+    throw new Error('--sha must be the full 40-character release commit');
+  }
+  return options;
+}
+
+export function runWranglerCommand({
+  args,
+  cwd,
+  quiet = false,
+  env = process.env,
+  spawnImpl = spawn,
+  stderr = process.stderr,
+  stdout = process.stdout,
+  timeoutMs = 120_000,
+}) {
+  const child = spawnImpl(
+    process.execPath,
+    [wranglerEntrypoint, ...args],
+    { cwd, env, stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+  let stderrOutput = '';
+  let stdoutOutput = '';
+  let timedOut = false;
+  let forceKillTimer;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    child.kill('SIGTERM');
+    forceKillTimer = setTimeout(() => child.kill('SIGKILL'), 5_000);
+  }, timeoutMs);
+  const clearTimers = () => {
+    clearTimeout(timeout);
+    if (forceKillTimer !== undefined) clearTimeout(forceKillTimer);
+  };
+  child.stdout.on('data', (chunk) => {
+    const text = chunk.toString();
+    stdoutOutput += text;
+    if (!quiet) stdout.write(text);
+  });
+  child.stderr.on('data', (chunk) => {
+    const text = chunk.toString();
+    stderrOutput += text;
+    if (!quiet) stderr.write(text);
+  });
+  return new Promise((resolvePromise, reject) => {
+    child.once('error', (error) => {
+      clearTimers();
+      reject(error);
+    });
+    child.once('close', (code, signal) => {
+      clearTimers();
+      if (timedOut) {
+        reject(new Error(`Wrangler command timed out after ${timeoutMs} ms`));
+        return;
+      }
+      if (signal !== null) {
+        reject(new Error(`Wrangler terminated by ${signal}`));
+        return;
+      }
+      resolvePromise({ exitCode: code ?? 1, stderr: stderrOutput, stdout: stdoutOutput });
+    });
+  });
+}
+
+function requireWranglerSuccess(result, operation) {
+  if (result.exitCode !== 0) {
+    throw new Error(`${operation} failed with exit code ${result.exitCode}`);
+  }
+  return result;
+}
+
+function rejectWhenAborted(signal, message) {
+  return new Promise((_, reject) => {
+    function onAbort() {
+      reject(signal.reason ?? new Error(message));
+    }
+    if (signal.aborted) onAbort();
+    else signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+async function deploymentVersion(worker, runWrangler) {
+  const result = requireWranglerSuccess(
+    await runWrangler({ cwd: worker.cwd, args: ['deployments', 'status', '--json'], quiet: true }),
+    `Reading ${worker.label} deployment`,
+  );
+  let status;
+  try {
+    status = JSON.parse(result.stdout);
+  } catch {
+    throw new Error(`Wrangler returned invalid deployment JSON for ${worker.label}`);
+  }
+  return parseActiveVersion(status, worker.label);
+}
+
+async function uploadVersion(worker, { tag, sha }, runWrangler) {
+  const result = requireWranglerSuccess(
+    await runWrangler({
+      cwd: worker.cwd,
+      args: [
+        'versions', 'upload',
+        '--tag', tag,
+        '--message', `${worker.label} ${tag} (${sha})`,
+        '--keep-vars',
+        '--strict',
+      ],
+    }),
+    `Uploading ${worker.label}`,
+  );
+  return parseUploadedVersionId(result.stdout, result.stderr);
+}
+
+async function promoteVersion(worker, versionId, { tag, sha }, runWrangler) {
+  requireWranglerSuccess(
+    await runWrangler({
+      cwd: worker.cwd,
+      args: [
+        'versions', 'deploy', `${versionId}@100`, '-y',
+        '--message', `${worker.label} ${tag} (${sha})`,
+      ],
+    }),
+    `Promoting ${worker.label}`,
+  );
+}
+
+async function rollbackVersion(worker, versionId, { tag, sha }, runWrangler) {
+  requireWranglerSuccess(
+    await runWrangler({
+      cwd: worker.cwd,
+      args: [
+        'rollback', versionId, '-y',
+        '--message', `Automatic rollback after failed ${tag} deployment (${sha})`,
+      ],
+    }),
+    `Rolling back ${worker.label}`,
+  );
+}
+
+async function fetchOk(fetchImpl, url, label) {
+  const response = await fetchImpl(url, {
+    redirect: 'error',
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!response.ok) throw new Error(`${label} returned HTTP ${response.status}`);
+  return response;
+}
+
+export async function readHealthVersion(baseUrl, fetchImpl = fetch) {
+  const response = await fetchOk(fetchImpl, new URL('/health', baseUrl), 'Health');
+  const health = await response.json();
+  if (typeof health?.version !== 'string' || !/^\d+\.\d+\.\d+$/u.test(health.version)) {
+    throw new Error('Health response did not include a semantic version');
+  }
+  return health.version;
+}
+
+export function createContinuityMonitor({
+  baseUrl,
+  fetchImpl = fetch,
+  intervalMs = 1_000,
+  probe = async () => {
+    await Promise.all([
+      fetchOk(fetchImpl, new URL('/health', baseUrl), 'Continuity health probe'),
+      fetchOk(fetchImpl, new URL('/docs/', baseUrl), 'Continuity docs probe'),
+    ]);
+  },
+} = {}) {
+  let stopped = false;
+  let failure;
+  let timer;
+  let wake;
+  let settleReady;
+  let rejectReady;
+  let reportFailure;
+  const ready = new Promise((resolvePromise, reject) => {
+    settleReady = resolvePromise;
+    rejectReady = reject;
+  });
+  const failed = new Promise((resolvePromise) => {
+    reportFailure = resolvePromise;
+  });
+  let firstProbe = true;
+
+  const loop = (async () => {
+    while (!stopped) {
+      try {
+        await probe();
+        if (firstProbe) settleReady();
+      } catch (error) {
+        failure = new Error(`Production continuity probe failed: ${messageFrom(error)}`);
+        reportFailure(failure);
+        if (firstProbe) rejectReady(failure);
+        return;
+      } finally {
+        firstProbe = false;
+      }
+      if (stopped) return;
+      await new Promise((resolvePromise) => {
+        wake = resolvePromise;
+        timer = setTimeout(resolvePromise, intervalMs);
+      });
+      timer = undefined;
+      wake = undefined;
+    }
+  })();
+
+  return {
+    ready,
+    failed,
+    assertHealthy() {
+      if (failure) throw failure;
+    },
+    async stop({ assertHealthy = true } = {}) {
+      stopped = true;
+      if (timer !== undefined) clearTimeout(timer);
+      wake?.();
+      await loop;
+      if (assertHealthy && failure) throw failure;
+    },
+  };
+}
+
+async function writeGithubOutputs(path, values) {
+  if (!path) return;
+  const output = Object.entries(values).map(([key, value]) => `${key}=${value}\n`).join('');
+  await appendFile(path, output, 'utf8');
+}
+
+async function rollbackDeployment({
+  changed,
+  previous,
+  release,
+  baseUrl,
+  runWrangler,
+  verifyRollback,
+}) {
+  const errors = [];
+  for (const key of ['mcp', 'docs']) {
+    if (!changed[key]) continue;
+    try {
+      await rollbackVersion(workers[key], previous[key], release, runWrangler);
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+
+  for (const key of ['mcp', 'docs']) {
+    try {
+      const active = await deploymentVersion(workers[key], runWrangler);
+      if (active !== previous[key]) {
+        throw new Error(`${workers[key].label} rollback left ${active} active; expected ${previous[key]}`);
+      }
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+
+  try {
+    await verifyRollback({ baseUrl, expectedVersion: previous.healthVersion });
+  } catch (error) {
+    errors.push(error);
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(errors, 'Automatic production rollback did not complete cleanly');
+  }
+}
+
+export async function deployProduction({
+  tag,
+  sha,
+  baseUrl = 'https://mcp.oath.md',
+  githubOutput = process.env.GITHUB_OUTPUT,
+} = {}, {
+  runWrangler = runWranglerCommand,
+  fetchImpl = fetch,
+  monitorFactory = createContinuityMonitor,
+  verifyProductionImpl = verifyProduction,
+  verifyRollbackImpl = verifyRollbackProduction,
+  writeOutputs = writeGithubOutputs,
+  log = console.log,
+} = {}) {
+  if (!/^v\d+\.\d+\.\d+$/u.test(tag ?? '')) throw new Error('A vX.Y.Z release tag is required');
+  if (!/^[0-9a-f]{40}$/iu.test(sha ?? '')) throw new Error('A full release commit SHA is required');
+  const release = { tag, sha };
+
+  const previous = {
+    mcp: await deploymentVersion(workers.mcp, runWrangler),
+    docs: await deploymentVersion(workers.docs, runWrangler),
+    healthVersion: await readHealthVersion(baseUrl, fetchImpl),
+  };
+  log(
+    `Captured production baseline: MCP ${previous.mcp}; docs ${previous.docs}; ` +
+    `health ${previous.healthVersion}.`,
+  );
+
+  const uploaded = {
+    mcp: await uploadVersion(workers.mcp, release, runWrangler),
+    docs: await uploadVersion(workers.docs, release, runWrangler),
+  };
+  log(`Uploaded without changing traffic: MCP ${uploaded.mcp}; docs ${uploaded.docs}.`);
+
+  const changed = { docs: false, mcp: false };
+  const monitor = monitorFactory({ baseUrl, fetchImpl });
+  try {
+    await monitor.ready;
+
+    changed.docs = true;
+    await promoteVersion(workers.docs, uploaded.docs, release, runWrangler);
+    await fetchOk(fetchImpl, new URL('/docs/', baseUrl), 'Promoted Blume docs');
+    monitor.assertHealthy();
+
+    changed.mcp = true;
+    await promoteVersion(workers.mcp, uploaded.mcp, release, runWrangler);
+    monitor.assertHealthy();
+
+    const verificationAbort = new AbortController();
+    const verificationDeadline = AbortSignal.timeout(360_000);
+    const verificationSignal = AbortSignal.any([
+      verificationAbort.signal,
+      verificationDeadline,
+    ]);
+    const verification = verifyProductionImpl({
+      baseUrl,
+      signal: verificationSignal,
+      timeoutMs: 300_000,
+    });
+    try {
+      await Promise.race([
+        verification,
+        monitor.failed.then((failure) => { throw failure; }),
+        rejectWhenAborted(verificationDeadline, 'Production verification timed out'),
+      ]);
+    } catch (error) {
+      verificationAbort.abort();
+      void verification.catch(() => undefined);
+      throw error;
+    }
+    monitor.assertHealthy();
+
+    const active = {
+      mcp: await deploymentVersion(workers.mcp, runWrangler),
+      docs: await deploymentVersion(workers.docs, runWrangler),
+    };
+    if (active.mcp !== uploaded.mcp || active.docs !== uploaded.docs) {
+      throw new Error(
+        `Production version confirmation failed: MCP ${active.mcp}; docs ${active.docs}`,
+      );
+    }
+    await monitor.stop();
+
+    const outputs = {
+      mcp_version_id: uploaded.mcp,
+      docs_version_id: uploaded.docs,
+      previous_mcp_version_id: previous.mcp,
+      previous_docs_version_id: previous.docs,
+      previous_version: previous.healthVersion,
+    };
+    await writeOutputs(githubOutput, outputs);
+    log(`Production cutover verified: MCP ${uploaded.mcp}; docs ${uploaded.docs}.`);
+    return outputs;
+  } catch (error) {
+    await monitor.stop({ assertHealthy: false });
+    if (!changed.mcp && !changed.docs) throw error;
+    try {
+      await rollbackDeployment({
+        changed,
+        previous,
+        release,
+        baseUrl,
+        runWrangler,
+        verifyRollback: verifyRollbackImpl,
+      });
+    } catch (rollbackError) {
+      throw new AggregateError(
+        [error, rollbackError],
+        `Production deployment failed and rollback needs attention: ${messageFrom(error)}`,
+      );
+    }
+    throw new Error(`Production deployment failed and was rolled back: ${messageFrom(error)}`, {
+      cause: error,
+    });
+  }
+}
+
+async function runCli() {
+  const options = parseDeployArgs(process.argv.slice(2));
+  await deployProduction(options);
+}
+
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  await runCli();
+}

--- a/scripts/release/verify-production.d.mts
+++ b/scripts/release/verify-production.d.mts
@@ -9,4 +9,40 @@ export interface McpReleaseContract {
 export function verifyMcpSurface(
   baseUrl: string | URL,
   release: McpReleaseContract,
+  options?: { signal?: AbortSignal },
 ): Promise<void>;
+
+export function verifyLegacyMcpSurface(
+  baseUrl: string | URL,
+  clientVersion: string,
+): Promise<void>;
+
+export function loadRelease(): Promise<McpReleaseContract>;
+
+export function verifyOnce(
+  baseUrl: string | URL,
+  release: McpReleaseContract,
+  options?: { fetchImpl?: typeof fetch; signal?: AbortSignal },
+): Promise<void>;
+
+export function verifyProduction(options?: {
+  baseUrl?: string | URL;
+  timeoutMs?: number;
+  loadReleaseImpl?: () => Promise<McpReleaseContract>;
+  verifyOnceImpl?: (
+    baseUrl: string | URL,
+    release: McpReleaseContract,
+    options?: { signal?: AbortSignal },
+  ) => Promise<void>;
+  log?: (message: string) => void;
+  signal?: AbortSignal;
+}): Promise<McpReleaseContract>;
+
+export function verifyRollbackProduction(options: {
+  baseUrl?: string | URL;
+  expectedVersion: string;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+  verifyLegacyImpl?: (baseUrl: string | URL, clientVersion: string) => Promise<void>;
+  log?: (message: string) => void;
+}): Promise<void>;

--- a/scripts/release/verify-production.mjs
+++ b/scripts/release/verify-production.mjs
@@ -46,7 +46,7 @@ function compareVersions(left, right) {
   return 0;
 }
 
-async function loadRelease() {
+export async function loadRelease() {
   const packageJson = JSON.parse(await readFile(resolve(root, "package.json"), "utf8"));
   const version = packageJson.version;
   const releasesDir = resolve(root, "validation", "releases");
@@ -145,7 +145,39 @@ async function calculateNewEntries(client, calculatorIds) {
   }
 }
 
-export async function verifyMcpSurface(baseUrl, release) {
+export async function verifyLegacyMcpSurface(baseUrl, clientVersion) {
+  const legacyClient = new Client(
+    { name: "oathmcp-release-verifier-legacy", version: clientVersion },
+    { versionNegotiation: { mode: "legacy" } },
+  );
+  try {
+    await legacyClient.connect(new StreamableHTTPClientTransport(new URL("/mcp", baseUrl)));
+    if (legacyClient.getProtocolEra() !== "legacy") {
+      throw new Error("Production MCP compatibility smoke did not negotiate the legacy era");
+    }
+    const { tools } = await legacyClient.listTools();
+    if (!tools.some((tool) => tool.name === "calculate")) {
+      throw new Error("Production legacy compatibility smoke is missing calculate");
+    }
+    await legacyClient.readResource({ uri: "oath://responsible-use" });
+    const calculation = await legacyClient.callTool({
+      name: "calculate",
+      arguments: { id: "bmi", inputs: { weight_kg: 70, height_cm: 170 } },
+    });
+    if (
+      calculation.isError === true ||
+      calculation.structuredContent?.result?.calculator !== "bmi" ||
+      calculation.structuredContent.result.ok !== true
+    ) {
+      throw new Error("Production legacy compatibility BMI smoke failed");
+    }
+  } finally {
+    await legacyClient.close();
+  }
+}
+
+export async function verifyMcpSurface(baseUrl, release, { signal } = {}) {
+  signal?.throwIfAborted();
   const modernClient = new Client(
     { name: "oathmcp-release-verifier-modern", version: release.version },
     { versionNegotiation: { mode: { pin: MODERN_PROTOCOL_VERSION } } },
@@ -196,50 +228,72 @@ export async function verifyMcpSurface(baseUrl, release) {
       }
     }
     await modernClient.readResource({ uri: "oath://responsible-use" });
+
+    const discovery = await modernClient.callTool({
+      name: "find_calculator",
+      arguments: { query: "body mass index" },
+    });
+    if (discovery.isError === true) {
+      throw new Error("Production modern calculator discovery failed");
+    }
+
+    const bmi = await modernClient.callTool({
+      name: "calculate",
+      arguments: { id: "bmi", inputs: { weight_kg: 70, height_cm: 170 } },
+    });
+    if (
+      bmi.isError === true ||
+      bmi.structuredContent?.result?.calculator !== "bmi" ||
+      bmi.structuredContent.result.ok !== true
+    ) {
+      throw new Error("Production modern BMI calculation failed");
+    }
+
+    const panel = await modernClient.callTool({
+      name: "calculate_panel",
+      arguments: {
+        calculators: ["bmi", "qsofa"],
+        inputs: {},
+        overrides: {
+          bmi: { weight_kg: 70, height_cm: 170 },
+          qsofa: { respiratory_rate: 24, systolic_bp: 90, altered_mental_status: true },
+        },
+      },
+    });
+    const panelResults = panel.structuredContent?.results;
+    if (
+      panel.isError === true ||
+      !Array.isArray(panelResults) ||
+      panelResults.length !== 2 ||
+      panelResults.some((entry) => entry?.ok !== true)
+    ) {
+      throw new Error("Production modern panel calculation failed");
+    }
+
     await calculateNewEntries(modernClient, release.newCalculatorIds);
   } finally {
     await modernClient.close();
   }
-
-  const legacyClient = new Client(
-    { name: "oathmcp-release-verifier-legacy", version: release.version },
-    { versionNegotiation: { mode: "legacy" } },
-  );
-  try {
-    await legacyClient.connect(new StreamableHTTPClientTransport(new URL("/mcp", baseUrl)));
-    if (legacyClient.getProtocolEra() !== "legacy") {
-      throw new Error("Production MCP compatibility smoke did not negotiate the legacy era");
-    }
-    const { tools } = await legacyClient.listTools();
-    if (!tools.some((tool) => tool.name === "calculate")) {
-      throw new Error("Production legacy compatibility smoke is missing calculate");
-    }
-    await legacyClient.readResource({ uri: "oath://responsible-use" });
-    const calculation = await legacyClient.callTool({
-      name: "calculate",
-      arguments: { id: "bmi", inputs: { weight_kg: 70, height_cm: 170 } },
-    });
-    if (calculation.isError === true) {
-      throw new Error("Production legacy compatibility BMI smoke failed");
-    }
-  } finally {
-    await legacyClient.close();
-  }
+  signal?.throwIfAborted();
+  await verifyLegacyMcpSurface(baseUrl, release.version);
+  signal?.throwIfAborted();
 }
 
-async function verifyOnce(baseUrl, release) {
-  const healthResponse = await fetch(new URL("/health", baseUrl), { redirect: "error" });
+export async function verifyOnce(baseUrl, release, { fetchImpl = fetch, signal } = {}) {
+  signal?.throwIfAborted();
+  const healthResponse = await fetchImpl(new URL("/health", baseUrl), { redirect: "error", signal });
   if (!healthResponse.ok) throw new Error(`Health returned HTTP ${healthResponse.status}`);
   const health = await healthResponse.json();
   if (health.version !== release.version) {
     throw new Error(`Production reports ${health.version}; expected ${release.version}`);
   }
 
-  await verifyMcpSurface(baseUrl, release);
+  await verifyMcpSurface(baseUrl, release, { signal });
 
   const docsPaths = await calculatorDocsPaths(release.attestation.calculatorIds);
   for (const [id, path] of docsPaths) {
-    const response = await fetch(new URL(path, baseUrl));
+    signal?.throwIfAborted();
+    const response = await fetchImpl(new URL(path, baseUrl), { signal });
     if (!response.ok) throw new Error(`Blume page for ${id} returned HTTP ${response.status}: ${path}`);
     const spec = YAML.parse(await readFile(resolve(root, "specs", `${id}.yaml`), "utf8"));
     if (!(await response.text()).includes(spec.name)) {
@@ -247,34 +301,132 @@ async function verifyOnce(baseUrl, release) {
     }
   }
 
-  const responsibleUse = await fetch(new URL("/responsible-use", baseUrl));
+  const responsibleUse = await fetchImpl(new URL("/responsible-use", baseUrl), { signal });
   if (!responsibleUse.ok) throw new Error(`Responsible Use returned HTTP ${responsibleUse.status}`);
 }
 
-async function runCli() {
-  const options = parseArgs(process.argv.slice(2));
-  const release = await loadRelease();
+function abortableDelay(milliseconds, signal) {
+  if (signal === undefined) {
+    return new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds));
+  }
+  signal.throwIfAborted();
+  return new Promise((resolvePromise, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolvePromise();
+    }, milliseconds);
+    function onAbort() {
+      clearTimeout(timer);
+      reject(signal.reason);
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function raceWithSignal(operation, signal) {
+  signal.throwIfAborted();
+  return new Promise((resolvePromise, reject) => {
+    function onAbort() {
+      reject(signal.reason ?? new Error("Operation aborted"));
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+    operation.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolvePromise(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+export async function verifyProduction({
+  baseUrl = "https://mcp.oath.md",
+  timeoutMs = 300_000,
+  loadReleaseImpl = loadRelease,
+  verifyOnceImpl = verifyOnce,
+  log = console.log,
+  signal,
+} = {}) {
+  const release = await loadReleaseImpl();
+  const deadlineSignal = AbortSignal.timeout(timeoutMs + 60_000);
+  const verificationSignal = signal === undefined
+    ? deadlineSignal
+    : AbortSignal.any([signal, deadlineSignal]);
   const startedAt = Date.now();
   let lastError;
   do {
     try {
-      await verifyOnce(options.baseUrl, release);
-      console.log(
+      verificationSignal.throwIfAborted();
+      await raceWithSignal(
+        verifyOnceImpl(baseUrl, release, { signal: verificationSignal }),
+        verificationSignal,
+      );
+      log(
         `Production verification passed: ${release.version}; ` +
         `${release.attestation.calculatorIds.length} MCP calculators; ` +
         `${release.attestation.calculatorIds.length} Blume pages; ` +
         `${release.newCalculatorIds.length} newly published calculators exercised.`,
       );
-      return;
+      return release;
     } catch (error) {
       lastError = error;
-      if (Date.now() - startedAt >= options.timeoutMs) break;
-      console.log(`Production not ready: ${error instanceof Error ? error.message : String(error)}; retrying.`);
-      await new Promise((resolvePromise) => setTimeout(resolvePromise, 5_000));
+      if (Date.now() - startedAt >= timeoutMs) break;
+      log(`Production not ready: ${error instanceof Error ? error.message : String(error)}; retrying.`);
+      await abortableDelay(5_000, verificationSignal);
     }
   } while (true);
 
   throw lastError;
+}
+
+export async function verifyRollbackProduction({
+  baseUrl = "https://mcp.oath.md",
+  expectedVersion,
+  timeoutMs = 60_000,
+  fetchImpl = fetch,
+  verifyLegacyImpl = verifyLegacyMcpSurface,
+  log = console.log,
+} = {}) {
+  if (typeof expectedVersion !== "string" || expectedVersion.length === 0) {
+    throw new Error("Rollback verification requires the previous health version");
+  }
+
+  const startedAt = Date.now();
+  const deadlineSignal = AbortSignal.timeout(timeoutMs + 30_000);
+  let lastError;
+  do {
+    try {
+      await raceWithSignal((async () => {
+        const [healthResponse, docsResponse] = await Promise.all([
+          fetchImpl(new URL("/health", baseUrl), { redirect: "error", signal: deadlineSignal }),
+          fetchImpl(new URL("/docs/", baseUrl), { redirect: "error", signal: deadlineSignal }),
+        ]);
+        if (!healthResponse.ok) throw new Error(`Rollback health returned HTTP ${healthResponse.status}`);
+        if (!docsResponse.ok) throw new Error(`Rollback docs returned HTTP ${docsResponse.status}`);
+        const health = await healthResponse.json();
+        if (health.version !== expectedVersion) {
+          throw new Error(`Rollback reports ${health.version}; expected ${expectedVersion}`);
+        }
+        await verifyLegacyImpl(baseUrl, expectedVersion);
+      })(), deadlineSignal);
+      log(`Rollback verification passed: ${expectedVersion}; legacy BMI and Blume docs are available.`);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (Date.now() - startedAt >= timeoutMs) break;
+      await abortableDelay(2_000, deadlineSignal);
+    }
+  } while (true);
+
+  throw lastError;
+}
+
+async function runCli() {
+  await verifyProduction(parseArgs(process.argv.slice(2)));
 }
 
 if (

--- a/test/ci-workflows.test.ts
+++ b/test/ci-workflows.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, it } from 'vitest';
 import YAML from 'yaml';
 
 interface Workflow {
+  concurrency?: {
+    group?: string;
+    'cancel-in-progress'?: boolean;
+  };
   on: {
     push?: {
       branches?: string[];
@@ -15,6 +19,7 @@ interface Workflow {
     if?: string;
     needs?: string | string[];
     environment?: string | { name?: string; url?: string };
+    'timeout-minutes'?: number;
     steps?: Array<{ run?: string }>;
   }>;
 }
@@ -51,25 +56,37 @@ describe('GitHub workflow boundaries', () => {
     const workflow = loadWorkflow('.github/workflows/release-readiness.yml');
     const commands = runCommands(workflow);
     const validateReleaseCommands = runCommands(workflow, 'validate-release');
+    const coordinator = readFileSync('scripts/release/deploy-production.mjs', 'utf8');
 
     expect(workflow.on.push?.tags).toEqual(['v*']);
     expect(Object.hasOwn(workflow.on, 'workflow_dispatch')).toBe(true);
+    expect(workflow.concurrency).toEqual({
+      group: 'oathmcp-production-release',
+      'cancel-in-progress': false,
+    });
     expect(validateReleaseCommands).toEqual(expect.arrayContaining([
       'npm run check:release',
       'npm run check:worker',
     ]));
-    expect(commands).toContain('npm run verify:production');
+    expect(commands.some((command) => command.includes('npm run deploy:production'))).toBe(true);
     expect(commands.some((command) => command.includes('npm publish --access public'))).toBe(true);
     expect(commands.some((command) => command.includes('npm run check:release-metadata -- --tag'))).toBe(true);
     expect(commands.some((command) => command.includes('git merge-base --is-ancestor'))).toBe(true);
-    expect(commands.filter((command) => command.includes('npx wrangler deploy'))).toHaveLength(2);
+    expect(commands.some((command) => command.includes('npx wrangler deploy'))).toBe(false);
+    expect(coordinator.match(/'versions', 'upload'/gu)).toHaveLength(1);
+    expect(coordinator.match(/'versions', 'deploy'/gu)).toHaveLength(1);
+    expect(coordinator).toContain("`${versionId}@100`");
+    expect(coordinator).toContain("for (const key of ['mcp', 'docs'])");
+    expect(coordinator).toContain('const verification = verifyProductionImpl({');
     expect(commands.some((command) => command.includes('gh release create'))).toBe(true);
 
     expect(workflow.jobs['deploy-production']?.if).toContain("refs/tags/v");
     expect(workflow.jobs['deploy-production']?.needs).toBe('validate-release');
-    expect(workflow.jobs['verify-production']?.needs).toBe('deploy-production');
+    expect(workflow.jobs['verify-production']).toBeUndefined();
+    expect(workflow.jobs['publish-npm']?.needs).toBe('deploy-production');
     expect(workflow.jobs['publish-npm']?.if).toContain('NPM_PUBLISH_ENABLED');
     expect(workflow.jobs['deploy-production']?.environment).toMatchObject({ name: 'production' });
+    expect(workflow.jobs['deploy-production']?.['timeout-minutes']).toBeGreaterThanOrEqual(45);
   });
 
   it('resolves the release attestation from the package version and includes Blume in the release gate', () => {

--- a/test/release/deploy-production.test.ts
+++ b/test/release/deploy-production.test.ts
@@ -1,0 +1,268 @@
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createContinuityMonitor,
+  deployProduction,
+  parseActiveVersion,
+  parseUploadedVersionId,
+  runWranglerCommand,
+} from '../../scripts/release/deploy-production.mjs';
+
+const SHA = 'a'.repeat(40);
+const PREVIOUS = {
+  mcp: '11111111-1111-4111-8111-111111111111',
+  docs: '22222222-2222-4222-8222-222222222222',
+};
+const UPLOADED = {
+  mcp: '33333333-3333-4333-8333-333333333333',
+  docs: '44444444-4444-4444-8444-444444444444',
+};
+
+function workerKey(cwd: string): keyof typeof PREVIOUS {
+  return cwd.endsWith('docs-site') ? 'docs' : 'mcp';
+}
+
+function response(body: string, contentType = 'text/plain'): Response {
+  return new Response(body, { status: 200, headers: { 'content-type': contentType } });
+}
+
+function createHarness({
+  fail,
+  splitMcp = false,
+}: {
+  fail?: (event: string) => boolean;
+  splitMcp?: boolean;
+} = {}) {
+  const events: string[] = [];
+  const active = { ...PREVIOUS };
+  const runWrangler = vi.fn(async ({ args, cwd }: { args: string[]; cwd: string }) => {
+    const key = workerKey(cwd);
+    const event = `${key}:${args.join(' ')}`;
+    events.push(event);
+
+    if (args[0] === 'deployments') {
+      const versions = splitMcp && key === 'mcp' && active.mcp === PREVIOUS.mcp
+        ? [
+            { version_id: PREVIOUS.mcp, percentage: 50 },
+            { version_id: UPLOADED.mcp, percentage: 50 },
+          ]
+        : [{ version_id: active[key], percentage: 100 }];
+      return { exitCode: 0, stderr: '', stdout: JSON.stringify({ versions }) };
+    }
+    if (args[0] === 'versions' && args[1] === 'upload') {
+      if (fail?.(event)) return { exitCode: 1, stderr: 'upload failed', stdout: '' };
+      return { exitCode: 0, stderr: '', stdout: `Worker Version ID: ${UPLOADED[key]}\n` };
+    }
+    if (args[0] === 'versions' && args[1] === 'deploy') {
+      active[key] = UPLOADED[key];
+      if (fail?.(event)) return { exitCode: 1, stderr: 'promotion failed', stdout: '' };
+      return { exitCode: 0, stderr: '', stdout: 'deployed' };
+    }
+    if (args[0] === 'rollback') {
+      if (fail?.(event)) return { exitCode: 1, stderr: 'rollback failed', stdout: '' };
+      active[key] = PREVIOUS[key];
+      return { exitCode: 0, stderr: '', stdout: 'rolled back' };
+    }
+    throw new Error(`Unexpected Wrangler command: ${event}`);
+  });
+  const fetchImpl = vi.fn(async (input: URL | RequestInfo) => {
+    const url = new URL(String(input));
+    if (url.pathname === '/health') {
+      return response(JSON.stringify({ version: '0.1.0' }), 'application/json');
+    }
+    return response('ok');
+  }) as unknown as typeof fetch;
+  const monitor = {
+    ready: Promise.resolve(),
+    failed: new Promise<Error>(() => undefined),
+    assertHealthy: vi.fn(),
+    stop: vi.fn(async () => undefined),
+  };
+  const monitorFactory = vi.fn(() => monitor);
+  const verifyProductionImpl = vi.fn(async (
+    _options: { baseUrl: string | URL; signal: AbortSignal; timeoutMs: number },
+  ) => undefined);
+  const verifyRollbackImpl = vi.fn(async () => undefined);
+  const writeOutputs = vi.fn(async () => undefined);
+
+  return {
+    active,
+    events,
+    fetchImpl,
+    monitor,
+    monitorFactory,
+    runWrangler,
+    verifyProductionImpl,
+    verifyRollbackImpl,
+    writeOutputs,
+  };
+}
+
+async function execute(harness: ReturnType<typeof createHarness>) {
+  return deployProduction(
+    { tag: 'v0.2.0', sha: SHA, githubOutput: '/tmp/github-output' },
+    { ...harness, log: vi.fn() },
+  );
+}
+
+describe('rollback-safe production deployment', () => {
+  it('requires a single version receiving all production traffic', () => {
+    expect(parseActiveVersion({
+      versions: [{ version_id: PREVIOUS.mcp, percentage: 100 }],
+    }, 'MCP Worker')).toBe(PREVIOUS.mcp);
+    expect(() => parseActiveVersion({
+      versions: [
+        { version_id: PREVIOUS.mcp, percentage: 50 },
+        { version_id: UPLOADED.mcp, percentage: 50 },
+      ],
+    }, 'MCP Worker')).toThrow('exactly one active production version');
+  });
+
+  it('parses the version ID emitted by a Wrangler version upload', () => {
+    expect(parseUploadedVersionId(`Worker Version ID: ${UPLOADED.mcp}`)).toBe(UPLOADED.mcp);
+    expect(() => parseUploadedVersionId('uploaded')).toThrow('did not report a Worker Version ID');
+  });
+
+  it('terminates a Wrangler command that exceeds its internal deadline', async () => {
+    const child = Object.assign(new EventEmitter(), {
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      kill: vi.fn((signal: NodeJS.Signals) => {
+        queueMicrotask(() => child.emit('close', null, signal));
+        return true;
+      }),
+    });
+
+    await expect(runWranglerCommand({
+      args: ['versions', 'deploy', `${UPLOADED.mcp}@100`, '-y'],
+      cwd: process.cwd(),
+      spawnImpl: (() => child) as unknown as typeof import('node:child_process').spawn,
+      stderr: new PassThrough(),
+      stdout: new PassThrough(),
+      timeoutMs: 1,
+    })).rejects.toThrow('timed out after 1 ms');
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('uploads both versions before promoting docs and then MCP to 100%', async () => {
+    const harness = createHarness();
+    const result = await execute(harness);
+
+    expect(result).toMatchObject({
+      mcp_version_id: UPLOADED.mcp,
+      docs_version_id: UPLOADED.docs,
+      previous_mcp_version_id: PREVIOUS.mcp,
+      previous_docs_version_id: PREVIOUS.docs,
+      previous_version: '0.1.0',
+    });
+    const uploadMcp = harness.events.findIndex((event) => event.startsWith('mcp:versions upload'));
+    const uploadDocs = harness.events.findIndex((event) => event.startsWith('docs:versions upload'));
+    const deployDocs = harness.events.findIndex((event) => event.startsWith('docs:versions deploy'));
+    const deployMcp = harness.events.findIndex((event) => event.startsWith('mcp:versions deploy'));
+    expect(uploadMcp).toBeLessThan(uploadDocs);
+    expect(uploadDocs).toBeLessThan(deployDocs);
+    expect(deployDocs).toBeLessThan(deployMcp);
+    expect(harness.events[deployDocs]).toContain(`${UPLOADED.docs}@100`);
+    expect(harness.events[deployMcp]).toContain(`${UPLOADED.mcp}@100`);
+    expect(harness.verifyProductionImpl).toHaveBeenCalledOnce();
+    expect(harness.verifyRollbackImpl).not.toHaveBeenCalled();
+    expect(harness.writeOutputs).toHaveBeenCalledOnce();
+  });
+
+  it('does not roll back when an upload fails before traffic changes', async () => {
+    const harness = createHarness({ fail: (event) => event.startsWith('docs:versions upload') });
+    await expect(execute(harness)).rejects.toThrow('Uploading Blume docs Worker failed');
+    expect(harness.events.some((event) => event.includes(':rollback '))).toBe(false);
+    expect(harness.monitorFactory).not.toHaveBeenCalled();
+  });
+
+  it('rolls back docs when its promotion reports a failure', async () => {
+    const harness = createHarness({ fail: (event) => event.startsWith('docs:versions deploy') });
+    await expect(execute(harness)).rejects.toThrow('failed and was rolled back');
+    const rollbacks = harness.events.filter((event) => event.includes(':rollback '));
+    expect(rollbacks).toHaveLength(1);
+    expect(rollbacks[0]).toContain(`docs:rollback ${PREVIOUS.docs}`);
+  });
+
+  it('rolls back MCP first and docs second after a partial MCP cutover', async () => {
+    const harness = createHarness({ fail: (event) => event.startsWith('mcp:versions deploy') });
+    await expect(execute(harness)).rejects.toThrow('failed and was rolled back');
+    const rollbacks = harness.events.filter((event) => event.includes(':rollback '));
+    expect(rollbacks[0]).toContain(`mcp:rollback ${PREVIOUS.mcp}`);
+    expect(rollbacks[1]).toContain(`docs:rollback ${PREVIOUS.docs}`);
+    expect(harness.verifyRollbackImpl).toHaveBeenCalledWith(expect.objectContaining({
+      expectedVersion: '0.1.0',
+    }));
+  });
+
+  it('rolls back both Workers when complete production verification fails', async () => {
+    const harness = createHarness();
+    harness.verifyProductionImpl.mockRejectedValueOnce(new Error('verification failed'));
+    await expect(execute(harness)).rejects.toThrow('failed and was rolled back');
+    expect(harness.events.filter((event) => event.includes(':rollback '))).toHaveLength(2);
+    expect(harness.writeOutputs).not.toHaveBeenCalled();
+  });
+
+  it('treats a continuity-probe failure as a deployment failure', async () => {
+    const harness = createHarness();
+    harness.monitor.assertHealthy.mockImplementationOnce(() => {
+      throw new Error('continuity failed');
+    });
+    await expect(execute(harness)).rejects.toThrow('failed and was rolled back');
+    const rollbacks = harness.events.filter((event) => event.includes(':rollback '));
+    expect(rollbacks).toEqual([expect.stringContaining(`docs:rollback ${PREVIOUS.docs}`)]);
+  });
+
+  it('aborts live verification and rolls back immediately when a probe fails', async () => {
+    const harness = createHarness();
+    const probeFailure = new Error('continuity failed during verification');
+    harness.monitor.failed = Promise.resolve(probeFailure);
+    let signal: AbortSignal | undefined;
+    harness.verifyProductionImpl.mockImplementationOnce(async (options) => {
+      signal = options.signal;
+      await new Promise((_, reject) => {
+        signal?.addEventListener('abort', () => reject(signal?.reason), { once: true });
+      });
+    });
+
+    await expect(execute(harness)).rejects.toThrow('failed and was rolled back');
+    expect(signal?.aborted).toBe(true);
+    expect(harness.events.filter((event) => event.includes(':rollback '))).toHaveLength(2);
+  });
+
+  it('attempts every rollback and reports when rollback itself fails', async () => {
+    const harness = createHarness({
+      fail: (event) => event.startsWith('mcp:rollback'),
+    });
+    harness.verifyProductionImpl.mockRejectedValueOnce(new Error('verification failed'));
+    await expect(execute(harness)).rejects.toThrow('rollback needs attention');
+    const rollbacks = harness.events.filter((event) => event.includes(':rollback '));
+    expect(rollbacks).toHaveLength(2);
+    expect(rollbacks[1]).toContain('docs:rollback');
+  });
+
+  it('rejects split production traffic before uploading either Worker', async () => {
+    const harness = createHarness({ splitMcp: true });
+    await expect(execute(harness)).rejects.toThrow('exactly one active production version');
+    expect(harness.events.some((event) => event.includes(':versions upload'))).toBe(false);
+  });
+});
+
+describe('continuous cutover probes', () => {
+  it('records a failed response until the coordinator consumes it', async () => {
+    let calls = 0;
+    const monitor = createContinuityMonitor({
+      intervalMs: 1,
+      probe: async () => {
+        calls += 1;
+        if (calls > 1) throw new Error('HTTP 503');
+      },
+    });
+    await monitor.ready;
+    await vi.waitFor(() => expect(() => monitor.assertHealthy()).toThrow('HTTP 503'));
+    await monitor.stop({ assertHealthy: false });
+  });
+});


### PR DESCRIPTION
## Summary

- upload both tagged Cloudflare Worker versions before changing production traffic
- serialize releases and promote Blume docs before MCP, each directly to 100%
- continuously probe the live service and automatically restore captured versions on cutover or verification failure
- verify modern and legacy MCP clients, the complete catalog, calculator execution, and every generated documentation page
- remove direct production deploy shortcuts and document one tested recovery path

## Verification

- `npm run check`
- `npm --prefix docs-site run check`
- `npx wrangler versions upload --dry-run --keep-vars --strict` for both Worker configurations
- 13 deployment-coordinator tests covering success, upload failure, partial cutover, verification failure, probe failure, timeout, rollback failure, and split traffic
- independent deployment and workflow audits approved

## Release safety

The tagged workflow keeps npm publishing disabled unless `NPM_PUBLISH_ENABLED=true`. A GitHub release is created only after both Workers are at their intended versions and the complete live verifier passes.