### PR TITLE
build: prepare scoped npm publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,26 @@ jobs:
       - run: npm run build
       - run: npx vitest run test/transport/parity.e2e.test.ts
 
+  package-consumer:
+    strategy:
+      matrix:
+        node-version:
+          - 22
+          - 24
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm run check:package-consumer
+
   docs:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -79,14 +79,19 @@ jobs:
           npm run deploy:production -- --tag "$GITHUB_REF_NAME" --sha "$GITHUB_SHA"
 
   publish-npm:
-    if: startsWith(github.ref, 'refs/tags/v') && vars.NPM_PUBLISH_ENABLED == 'true'
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: deploy-production
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    environment: production
+    timeout-minutes: 25
+    environment: npm-publish
     permissions:
       contents: read
       id-token: write
+    outputs:
+      package_name: ${{ steps.publish.outputs.package_name }}
+      package_version: ${{ steps.publish.outputs.package_version }}
+      package_integrity: ${{ steps.publish.outputs.package_integrity }}
+      package_tarball: ${{ steps.publish.outputs.package_tarball }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -96,25 +101,59 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
+      - run: npm install --global npm@12.0.2
       - run: npm ci
-      - name: Publish package once
+      - name: Publish and verify the package once
+        id: publish
+        run: npm run publish:npm -- --sha "$GITHUB_SHA"
+      - name: Verify a clean registry consumer
+        env:
+          PACKAGE_NAME: ${{ steps.publish.outputs.package_name }}
+          PACKAGE_VERSION: ${{ steps.publish.outputs.package_version }}
+        run: npm run verify:npm-package -- --package-spec "$PACKAGE_NAME@$PACKAGE_VERSION"
+
+  rollback-after-npm-failure:
+    if: >-
+      always() &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.deploy-production.result == 'success' &&
+      needs.publish-npm.result == 'failure'
+    needs:
+      - deploy-production
+      - publish-npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: production
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Restore the captured production baseline
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PREVIOUS_MCP_VERSION_ID: ${{ needs.deploy-production.outputs.previous_mcp_version_id }}
+          PREVIOUS_DOCS_VERSION_ID: ${{ needs.deploy-production.outputs.previous_docs_version_id }}
+          PREVIOUS_VERSION: ${{ needs.deploy-production.outputs.previous_version }}
         run: |
-          package_version="$(node -p "require('./package.json').version")"
-          published_version="$(npm view "oath-mcp@$package_version" version 2>/dev/null || true)"
-          if [ "$published_version" = "$package_version" ]; then
-            published_git_head="$(npm view "oath-mcp@$package_version" gitHead 2>/dev/null || true)"
-            test "$published_git_head" = "$GITHUB_SHA"
-            echo "oath-mcp@$package_version is already published from this commit."
-          else
-            npm publish --access public
-          fi
+          npm run rollback:production -- \
+            --tag "$GITHUB_REF_NAME" \
+            --sha "$GITHUB_SHA" \
+            --mcp-version-id "$PREVIOUS_MCP_VERSION_ID" \
+            --docs-version-id "$PREVIOUS_DOCS_VERSION_ID" \
+            --expected-version "$PREVIOUS_VERSION"
 
   publish-github-release:
     if: >-
       always() &&
       startsWith(github.ref, 'refs/tags/v') &&
       needs.deploy-production.result == 'success' &&
-      (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped')
+      needs.publish-npm.result == 'success'
     needs:
       - deploy-production
       - publish-npm
@@ -128,10 +167,28 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
-          node-version: 22
-          cache: npm
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - run: npm install --global npm@12.0.2
       - run: npm ci
-      - run: mkdir -p release-artifacts && npm pack --pack-destination release-artifacts
+      - name: Download the exact registry tarball
+        env:
+          PACKAGE_NAME: ${{ needs.publish-npm.outputs.package_name }}
+          PACKAGE_VERSION: ${{ needs.publish-npm.outputs.package_version }}
+          PACKAGE_INTEGRITY: ${{ needs.publish-npm.outputs.package_integrity }}
+          PACKAGE_TARBALL: ${{ needs.publish-npm.outputs.package_tarball }}
+        run: |
+          mkdir -p release-artifacts
+          artifact="release-artifacts/oath-md-oath-mcp-$PACKAGE_VERSION.tgz"
+          curl --fail --location --silent --show-error "$PACKAGE_TARBALL" --output "$artifact"
+          ARTIFACT="$artifact" node --input-type=module <<'NODE'
+          import { createHash } from 'node:crypto';
+          import { readFileSync } from 'node:fs';
+          const [algorithm, expected] = process.env.PACKAGE_INTEGRITY.split('-', 2);
+          const actual = createHash(algorithm).update(readFileSync(process.env.ARTIFACT)).digest('base64');
+          if (actual !== expected) throw new Error('Downloaded npm tarball integrity mismatch');
+          NODE
       - name: Publish verified GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -140,10 +197,15 @@ jobs:
           PREVIOUS_MCP_VERSION_ID: ${{ needs.deploy-production.outputs.previous_mcp_version_id }}
           PREVIOUS_DOCS_VERSION_ID: ${{ needs.deploy-production.outputs.previous_docs_version_id }}
           PREVIOUS_VERSION: ${{ needs.deploy-production.outputs.previous_version }}
+          PACKAGE_NAME: ${{ needs.publish-npm.outputs.package_name }}
+          PACKAGE_VERSION: ${{ needs.publish-npm.outputs.package_version }}
+          PACKAGE_INTEGRITY: ${{ needs.publish-npm.outputs.package_integrity }}
         run: |
           notes="$(printf '%s\n' \
             "Production deployment verified from commit \`$GITHUB_SHA\`." \
             "" \
+            "- npm package: [\`$PACKAGE_NAME@$PACKAGE_VERSION\`](https://www.npmjs.com/package/$PACKAGE_NAME/v/$PACKAGE_VERSION)" \
+            "- npm integrity: \`$PACKAGE_INTEGRITY\`" \
             "- MCP Worker version: \`$MCP_VERSION_ID\`" \
             "- Blume docs Worker version: \`$DOCS_VERSION_ID\`" \
             "- Rollback baseline: OathMCP \`$PREVIOUS_VERSION\`, MCP \`$PREVIOUS_MCP_VERSION_ID\`, docs \`$PREVIOUS_DOCS_VERSION_ID\`" \

--- a/docs-site/scripts/generate-from-repo.mjs
+++ b/docs-site/scripts/generate-from-repo.mjs
@@ -21,8 +21,8 @@ for (const path of [
 }
 
 const packageJson = JSON.parse(await readFile(join(repositoryRoot, "package.json"), "utf8"));
-if (packageJson.name !== "oath-mcp") {
-  throw new Error(`Expected the docs site inside the oath-mcp repository: ${repositoryRoot}`);
+if (packageJson.name !== "@oath-md/oath-mcp") {
+  throw new Error(`Expected the docs site inside the OathMCP repository: ${repositoryRoot}`);
 }
 
 const canonical = await readFile(responsibleUsePath, "utf8");

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -14,7 +14,7 @@ draft
   -> MCP Worker
   -> Blume docs Worker
   -> live catalog/docs verification
-  -> optional npm publication
+  -> required npm publication
   -> GitHub release
 ```
 
@@ -154,7 +154,8 @@ publisher. A `v*` tag runs these ordered jobs:
 7. Open a separate explicit-legacy client and require the bounded
    list/resource/calculation smoke to pass.
 8. Fetch and verify one generated Blume page for every attested calculator.
-9. Optionally publish the npm package through trusted publishing.
+9. Publish the npm package through trusted publishing and verify a clean
+   registry consumer before the GitHub release is created.
 10. Attach the package tarball and both Cloudflare Worker version IDs to the
    GitHub release.
 
@@ -188,11 +189,20 @@ one owner: the tagged GitHub workflow. Reconnecting a `main` trigger creates an
 ambiguous second path that either fails against an unreleased attestation or
 deploys source that has not completed the release workflow.
 
-The npm job is disabled unless repository variable
-`NPM_PUBLISH_ENABLED=true`. Enable it only after the `oath-mcp` package has an
-[npm trusted publisher](https://docs.npmjs.com/trusted-publishers/) bound to this
-exact workflow. Trusted publishing uses GitHub OIDC; do not add a long-lived npm
-token to the repository.
+The npm job is mandatory for release tags and runs only after production passes.
+It uses the separately protected `npm-publish` environment and a
+[trusted publisher](https://docs.npmjs.com/trusted-publishers/) bound to this
+exact workflow. Trusted publishing uses GitHub OIDC; never add a long-lived npm
+token to the repository. The GitHub release remains withheld until the registry
+reports the exact package version, tag commit, latest dist-tag, tarball, and
+integrity and a clean registry consumer passes.
+
+The first publication is the one exception because npm requires a package to
+exist before trusted publishing can be configured. After the tagged Workers are
+verified, leave the `npm-publish` job awaiting review, publish the exact tag
+interactively with account 2FA, configure the trusted publisher, disallow
+traditional publish tokens, and only then approve the pending job. All later
+tags publish through OIDC.
 
 ## Manual readiness and recovery
 
@@ -219,7 +229,7 @@ See [Hosted Endpoint Operations](HOSTING.md).
 
 ## npm, license, and responsibility
 
-Before enabling npm publication, confirm the package name, public access,
+Before npm publication, confirm the scoped package name, public access,
 Apache-2.0 identity, `NOTICE`, package contents, and trusted-publisher binding.
 The package `prepublishOnly` hook repeats metadata, ordinary acceptance, and the
 clinical release gate.
@@ -237,4 +247,5 @@ for the deployed version, and [GitHub Releases](https://github.com/OATH-md/OathM
 identifies its exact tag and source. The `0.2.0` attestation covers the
 40-calculator catalog, including FIB-4. It becomes an official hosted release
 only after the tag workflow verifies both production Workers and creates the
-matching GitHub release. npm publication remains disabled.
+matching GitHub release. The `0.2.0` package was not published to npm; mandatory
+registry publication begins with the next tagged release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "oath-mcp",
+  "name": "@oath-md/oath-mcp",
   "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "oath-mcp",
+      "name": "@oath-md/oath-mcp",
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "oath-mcp",
+  "name": "@oath-md/oath-mcp",
   "version": "0.2.0",
   "description": "Agent-native MCP server for evidence-backed clinical calculators.",
   "license": "Apache-2.0",
@@ -8,7 +8,7 @@
     "node": ">=22"
   },
   "bin": {
-    "oath-mcp": "./dist/server/stdio.js"
+    "oath-mcp": "dist/server/stdio.js"
   },
   "files": [
     "dist",
@@ -42,6 +42,10 @@
   "bugs": {
     "url": "https://github.com/OATH-md/OathMCP/issues"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "keywords": [
     "mcp",
     "clinical-calculators",
@@ -62,12 +66,16 @@
     "check:clinical-release": "npm run validate:clinical -- --require-source-verified --require-scenario-verified --release-attestation auto",
     "release:prepare": "tsx src/cli/index.ts prepare-release",
     "check:release-metadata": "node scripts/release/check-metadata.mjs",
-    "check:release": "npm run check:release-metadata && npm run check && npm run check:clinical-release && npm --prefix docs-site run check && npm pack --dry-run",
+    "check:release": "npm run check:release-metadata && npm run check && npm run check:clinical-release && npm --prefix docs-site run check && npm run check:package-consumer && npm pack --dry-run",
     "deploy:production": "node scripts/release/deploy-production.mjs",
+    "rollback:production": "node scripts/release/rollback-production.mjs",
     "verify:production": "node scripts/release/verify-production.mjs",
+    "publish:npm": "node scripts/release/publish-npm.mjs",
+    "verify:npm-package": "node scripts/release/verify-package-consumer.mjs",
     "check:package": "vitest run test/package-manifest.test.ts",
+    "check:package-consumer": "node scripts/release/verify-package-consumer.mjs",
     "check": "npm run check:generated && npm run lint:specs && npm run validate:clinical -- --require-scenario-verified && npm run typecheck && npm run build && npm run test:run && npm run check:package",
-    "prepublishOnly": "npm run check:release-metadata && npm run check && npm run check:clinical-release",
+    "prepublishOnly": "npm run check:release-metadata && npm run check && npm run check:clinical-release && npm run check:package-consumer",
     "typecheck": "tsc -p tsconfig.test.json",
     "test": "npm run build && npm run test:run",
     "test:run": "vitest run --exclude test/package-manifest.test.ts",

--- a/scripts/release/deploy-production.d.mts
+++ b/scripts/release/deploy-production.d.mts
@@ -11,6 +11,28 @@ export interface ContinuityMonitor {
   stop(options?: { assertHealthy?: boolean }): Promise<void>;
 }
 
+export interface RestoreProductionOptions {
+  tag: string;
+  sha: string;
+  mcpVersionId: string;
+  docsVersionId: string;
+  expectedVersion: string;
+  baseUrl?: string | URL;
+}
+
+export interface RestoreProductionDependencies {
+  runWrangler?: (options: {
+    args: string[];
+    cwd: string;
+    quiet?: boolean;
+  }) => Promise<WranglerResult>;
+  verifyRollbackImpl?: (options: {
+    baseUrl: string | URL;
+    expectedVersion: string;
+  }) => Promise<void>;
+  log?: (message: string) => void;
+}
+
 export function parseActiveVersion(
   value: unknown,
   label: string,
@@ -78,3 +100,7 @@ export function deployProduction(
     log?: (message: string) => void;
   },
 ): Promise<Record<string, string>>;
+export function restoreProduction(
+  options: RestoreProductionOptions,
+  dependencies?: RestoreProductionDependencies,
+): Promise<void>;

--- a/scripts/release/deploy-production.mjs
+++ b/scripts/release/deploy-production.mjs
@@ -322,6 +322,47 @@ async function rollbackDeployment({
   }
 }
 
+export async function restoreProduction({
+  tag,
+  sha,
+  mcpVersionId,
+  docsVersionId,
+  expectedVersion,
+  baseUrl = 'https://mcp.oath.md',
+} = {}, {
+  runWrangler = runWranglerCommand,
+  verifyRollbackImpl = verifyRollbackProduction,
+  log = console.log,
+} = {}) {
+  if (!/^v\d+\.\d+\.\d+$/u.test(tag ?? '')) throw new Error('A vX.Y.Z release tag is required');
+  if (!/^[0-9a-f]{40}$/iu.test(sha ?? '')) throw new Error('A full release commit SHA is required');
+  for (const [label, value] of [
+    ['MCP version ID', mcpVersionId],
+    ['docs version ID', docsVersionId],
+  ]) {
+    if (!/^[0-9a-f-]{36}$/iu.test(value ?? '')) throw new Error(`${label} is required`);
+  }
+  if (!/^\d+\.\d+\.\d+$/u.test(expectedVersion ?? '')) {
+    throw new Error('An expected X.Y.Z health version is required');
+  }
+  await rollbackDeployment({
+    changed: { mcp: true, docs: true },
+    previous: {
+      mcp: mcpVersionId,
+      docs: docsVersionId,
+      healthVersion: expectedVersion,
+    },
+    release: { tag, sha },
+    baseUrl,
+    runWrangler,
+    verifyRollback: verifyRollbackImpl,
+  });
+  log(
+    `Production restored after npm release failure: MCP ${mcpVersionId}; ` +
+    `docs ${docsVersionId}; health ${expectedVersion}.`,
+  );
+}
+
 export async function deployProduction({
   tag,
   sha,

--- a/scripts/release/publish-npm.d.mts
+++ b/scripts/release/publish-npm.d.mts
@@ -1,0 +1,51 @@
+export interface PublishOutputs {
+  package_name: string;
+  package_version: string;
+  package_integrity: string;
+  package_tarball: string;
+}
+
+export interface NpmCommandResult {
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+}
+
+export interface PublishedPackageVersion {
+  name?: string;
+  version?: string;
+  gitHead?: string;
+  dist?: { integrity?: string; tarball?: string };
+}
+
+export interface NpmPackument {
+  'dist-tags'?: Record<string, string>;
+  versions?: Record<string, PublishedPackageVersion>;
+}
+
+export function parsePublishArgs(argv: string[]): { sha: string; timeoutMs?: number };
+export function runNpmCommand(options: Record<string, unknown>): Promise<NpmCommandResult>;
+export function readRegistryPackage(options: {
+  packageName: string;
+  registry?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<NpmPackument | undefined>;
+export function validatePublishedVersion(
+  packument: NpmPackument | undefined,
+  expected: { packageName: string; version: string; sha: string },
+): { integrity: string; tarball: string } | { pendingLatest: true } | undefined;
+export function publishNpm(
+  options: {
+    sha: string;
+    timeoutMs?: number;
+    githubOutput?: string;
+    projectRoot?: string;
+  },
+  dependencies?: {
+    fetchImpl?: typeof fetch;
+    runNpm?: (options: { args: string[]; cwd: string }) => Promise<NpmCommandResult>;
+    sleep?: (milliseconds: number) => Promise<void>;
+    writeOutputs?: (path: string | undefined, values: PublishOutputs) => Promise<void>;
+    log?: (message: string) => void;
+  },
+): Promise<PublishOutputs>;

--- a/scripts/release/publish-npm.mjs
+++ b/scripts/release/publish-npm.mjs
@@ -1,0 +1,232 @@
+import { spawn } from 'node:child_process';
+import { appendFile, readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const root = resolve(import.meta.dirname, '../..');
+const DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
+
+function messageFrom(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function parsePublishArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--sha' || token === '--timeout-ms') {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) throw new Error(`${token} requires a value`);
+      options[token.slice(2).replace('-ms', 'Ms')] = token === '--timeout-ms' ? Number(value) : value;
+      index += 1;
+    } else {
+      throw new Error(`Unknown option '${token}'`);
+    }
+  }
+  if (!/^[0-9a-f]{40}$/iu.test(options.sha ?? '')) {
+    throw new Error('--sha must be the full 40-character release commit');
+  }
+  if (options.timeoutMs !== undefined && (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0)) {
+    throw new Error('--timeout-ms must be a positive number');
+  }
+  return options;
+}
+
+export function runNpmCommand({
+  args,
+  cwd = root,
+  env = process.env,
+  spawnImpl = spawn,
+  stderr = process.stderr,
+  stdout = process.stdout,
+  timeoutMs = 600_000,
+}) {
+  const command = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const child = spawnImpl(command, args, { cwd, env, stdio: ['ignore', 'pipe', 'pipe'] });
+  let stderrOutput = '';
+  let stdoutOutput = '';
+  let timedOut = false;
+  let forceKillTimer;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    child.kill('SIGTERM');
+    forceKillTimer = setTimeout(() => child.kill('SIGKILL'), 5_000);
+  }, timeoutMs);
+  const clearTimers = () => {
+    clearTimeout(timeout);
+    if (forceKillTimer !== undefined) clearTimeout(forceKillTimer);
+  };
+  child.stdout.on('data', (chunk) => {
+    const text = chunk.toString();
+    stdoutOutput += text;
+    stdout.write(text);
+  });
+  child.stderr.on('data', (chunk) => {
+    const text = chunk.toString();
+    stderrOutput += text;
+    stderr.write(text);
+  });
+  return new Promise((resolvePromise, reject) => {
+    child.once('error', (error) => {
+      clearTimers();
+      reject(error);
+    });
+    child.once('close', (code, signal) => {
+      clearTimers();
+      if (timedOut) {
+        reject(new Error(`npm command timed out after ${timeoutMs} ms`));
+        return;
+      }
+      if (signal !== null) {
+        reject(new Error(`npm command terminated by ${signal}`));
+        return;
+      }
+      resolvePromise({ exitCode: code ?? 1, stderr: stderrOutput, stdout: stdoutOutput });
+    });
+  });
+}
+
+function registryPackageUrl(registry, packageName) {
+  const base = registry.endsWith('/') ? registry : `${registry}/`;
+  return new URL(encodeURIComponent(packageName), base);
+}
+
+export async function readRegistryPackage({
+  packageName,
+  registry = DEFAULT_REGISTRY,
+  fetchImpl = fetch,
+}) {
+  const response = await fetchImpl(registryPackageUrl(registry, packageName), {
+    headers: { accept: 'application/json' },
+    cache: 'no-store',
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (response.status === 404) return undefined;
+  if (!response.ok) throw new Error(`npm registry returned HTTP ${response.status}`);
+  return response.json();
+}
+
+export function validatePublishedVersion(packument, { packageName, version, sha }) {
+  const published = packument?.versions?.[version];
+  if (published === undefined) return undefined;
+  if (published.name !== packageName || published.version !== version) {
+    throw new Error(`npm registry returned unexpected metadata for ${packageName}@${version}`);
+  }
+  if (published.gitHead !== sha) {
+    throw new Error(
+      `${packageName}@${version} was published from ${String(published.gitHead)}; expected ${sha}`,
+    );
+  }
+  const integrity = published.dist?.integrity;
+  const tarball = published.dist?.tarball;
+  if (typeof integrity !== 'string' || !integrity.startsWith('sha512-')) {
+    throw new Error(`${packageName}@${version} is missing SHA-512 registry integrity`);
+  }
+  if (typeof tarball !== 'string' || !tarball.startsWith('https://registry.npmjs.org/')) {
+    throw new Error(`${packageName}@${version} is missing its registry tarball URL`);
+  }
+  if (packument?.['dist-tags']?.latest !== version) {
+    return { pendingLatest: true };
+  }
+  return { integrity, tarball };
+}
+
+function delay(ms) {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
+}
+
+async function readPackageMetadata(projectRoot) {
+  const packageJson = JSON.parse(await readFile(resolve(projectRoot, 'package.json'), 'utf8'));
+  const { name, version, publishConfig } = packageJson;
+  if (typeof name !== 'string' || !name.startsWith('@') || !name.includes('/')) {
+    throw new Error('package.json must declare an organization-scoped package name');
+  }
+  if (typeof version !== 'string' || !/^\d+\.\d+\.\d+$/u.test(version)) {
+    throw new Error('package.json must declare an exact X.Y.Z version');
+  }
+  const registry = publishConfig?.registry ?? DEFAULT_REGISTRY;
+  if (registry !== DEFAULT_REGISTRY || publishConfig?.access !== 'public') {
+    throw new Error('package.json must publish publicly to https://registry.npmjs.org/');
+  }
+  return { name, registry, version };
+}
+
+async function writeGithubOutputs(path, values) {
+  if (!path) return;
+  const output = Object.entries(values).map(([key, value]) => `${key}=${value}\n`).join('');
+  await appendFile(path, output, 'utf8');
+}
+
+export async function publishNpm({
+  sha,
+  timeoutMs = 120_000,
+  githubOutput = process.env.GITHUB_OUTPUT,
+  projectRoot = root,
+} = {}, {
+  fetchImpl = fetch,
+  runNpm = runNpmCommand,
+  sleep = delay,
+  writeOutputs = writeGithubOutputs,
+  log = console.log,
+} = {}) {
+  if (!/^[0-9a-f]{40}$/iu.test(sha ?? '')) throw new Error('A full release commit SHA is required');
+  const metadata = await readPackageMetadata(projectRoot);
+  const expected = { packageName: metadata.name, version: metadata.version, sha };
+  let packument = await readRegistryPackage({
+    packageName: metadata.name,
+    registry: metadata.registry,
+    fetchImpl,
+  });
+  let published = validatePublishedVersion(packument, expected);
+  let publishFailure;
+
+  if (published === undefined) {
+    const result = await runNpm({
+      args: ['publish', '--access', 'public'],
+      cwd: projectRoot,
+    });
+    if (result.exitCode !== 0) {
+      publishFailure = new Error(`npm publish failed with exit code ${result.exitCode}`);
+      log(`${publishFailure.message}; checking whether the registry accepted the package.`);
+    }
+  } else if (!published.pendingLatest) {
+    log(`${metadata.name}@${metadata.version} is already published from ${sha}.`);
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  while (published === undefined || published.pendingLatest) {
+    if (Date.now() >= deadline) {
+      const detail = publishFailure === undefined ? '' : `: ${messageFrom(publishFailure)}`;
+      throw new Error(`npm registry did not confirm ${metadata.name}@${metadata.version}${detail}`);
+    }
+    await sleep(Math.min(2_000, Math.max(1, deadline - Date.now())));
+    packument = await readRegistryPackage({
+      packageName: metadata.name,
+      registry: metadata.registry,
+      fetchImpl,
+    });
+    published = validatePublishedVersion(packument, expected);
+  }
+
+  const outputs = {
+    package_name: metadata.name,
+    package_version: metadata.version,
+    package_integrity: published.integrity,
+    package_tarball: published.tarball,
+  };
+  await writeOutputs(githubOutput, outputs);
+  log(`npm publication verified: ${metadata.name}@${metadata.version} (${sha}).`);
+  return outputs;
+}
+
+async function runCli() {
+  const options = parsePublishArgs(process.argv.slice(2));
+  await publishNpm(options);
+}
+
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  await runCli();
+}

--- a/scripts/release/rollback-production.mjs
+++ b/scripts/release/rollback-production.mjs
@@ -1,0 +1,37 @@
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { restoreProduction } from './deploy-production.mjs';
+
+export function parseRollbackArgs(argv) {
+  const options = { baseUrl: 'https://mcp.oath.md' };
+  const names = new Map([
+    ['--tag', 'tag'],
+    ['--sha', 'sha'],
+    ['--mcp-version-id', 'mcpVersionId'],
+    ['--docs-version-id', 'docsVersionId'],
+    ['--expected-version', 'expectedVersion'],
+    ['--base-url', 'baseUrl'],
+  ]);
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const name = names.get(token);
+    if (name === undefined) throw new Error(`Unknown option '${token}'`);
+    const value = argv[index + 1];
+    if (!value || value.startsWith('--')) throw new Error(`${token} requires a value`);
+    options[name] = value;
+    index += 1;
+  }
+  return options;
+}
+
+async function runCli() {
+  await restoreProduction(parseRollbackArgs(process.argv.slice(2)));
+}
+
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  await runCli();
+}

--- a/scripts/release/verify-package-consumer.mjs
+++ b/scripts/release/verify-package-consumer.mjs
@@ -1,0 +1,311 @@
+import { spawn } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { Client } from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
+
+const root = resolve(import.meta.dirname, '../..');
+const PACKAGE_NAME = '@oath-md/oath-mcp';
+const MODERN_PROTOCOL_VERSION = '2026-07-28';
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--package-spec') {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) throw new Error(`${token} requires a value`);
+      options.packageSpec = value;
+      index += 1;
+    } else {
+      throw new Error(`Unknown option '${token}'`);
+    }
+  }
+  return options;
+}
+
+function runCommand(command, args, {
+  cwd,
+  env = process.env,
+  timeoutMs = 300_000,
+} = {}) {
+  const child = spawn(command, args, { cwd, env, stdio: ['ignore', 'pipe', 'pipe'] });
+  let stderr = '';
+  let stdout = '';
+  let timedOut = false;
+  let forceKillTimer;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    child.kill('SIGTERM');
+    forceKillTimer = setTimeout(() => child.kill('SIGKILL'), 5_000);
+  }, timeoutMs);
+  const clearTimers = () => {
+    clearTimeout(timeout);
+    if (forceKillTimer !== undefined) clearTimeout(forceKillTimer);
+  };
+  child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
+  child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+  return new Promise((resolvePromise, reject) => {
+    child.once('error', (error) => {
+      clearTimers();
+      reject(error);
+    });
+    child.once('close', (code, signal) => {
+      clearTimers();
+      if (timedOut) {
+        reject(new Error(`${command} timed out after ${timeoutMs} ms`));
+      } else if (signal !== null) {
+        reject(new Error(`${command} terminated by ${signal}`));
+      } else {
+        resolvePromise({ exitCode: code ?? 1, stderr, stdout });
+      }
+    });
+  });
+}
+
+function requireSuccess(result, operation) {
+  if (result.exitCode !== 0) {
+    const detail = [result.stderr.trim(), result.stdout.trim()].filter(Boolean).join('\n');
+    throw new Error(`${operation} failed with exit code ${result.exitCode}: ${detail}`);
+  }
+  return result;
+}
+
+async function packLocalPackage(temporaryRoot) {
+  const packDirectory = join(temporaryRoot, 'pack');
+  await mkdir(packDirectory);
+  const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const result = requireSuccess(await runCommand(npm, [
+    'pack', '--ignore-scripts', '--json', '--pack-destination', packDirectory,
+  ], {
+    cwd: root,
+    env: { ...process.env, npm_config_dry_run: 'false' },
+  }), 'Packing the release candidate');
+  const manifest = JSON.parse(result.stdout);
+  const filename = manifest?.[0]?.filename;
+  if (typeof filename !== 'string' || !filename.endsWith('.tgz')) {
+    throw new Error('npm pack did not return a tarball filename');
+  }
+  return join(packDirectory, basename(filename));
+}
+
+async function verifyExports(consumerRoot) {
+  const runtimeVerifier = join(consumerRoot, 'verify-exports.mjs');
+  await writeFile(runtimeVerifier, `
+import { run } from '${PACKAGE_NAME}';
+import { buildServer } from '${PACKAGE_NAME}/server';
+
+if (typeof run !== 'function') throw new Error('${PACKAGE_NAME} did not export run()');
+if (typeof buildServer !== 'function') {
+  throw new Error('${PACKAGE_NAME}/server did not export buildServer()');
+}
+const bmi = run('bmi', { weight_kg: 70, height_cm: 170 });
+if (bmi?.results?.find(({ name }) => name === 'bmi')?.value !== 24.22) {
+  throw new Error('Installed engine BMI smoke did not return 24.22');
+}
+buildServer();
+`, 'utf8');
+  requireSuccess(
+    await runCommand(process.execPath, [runtimeVerifier], { cwd: consumerRoot }),
+    'Verifying installed JavaScript exports',
+  );
+
+  const typeVerifier = join(consumerRoot, 'verify-types.ts');
+  await writeFile(typeVerifier, `
+import { run } from '${PACKAGE_NAME}';
+import { buildServer } from '${PACKAGE_NAME}/server';
+
+const result = run('bmi', { weight_kg: 70, height_cm: 170 });
+const server = buildServer();
+void result;
+void server;
+`, 'utf8');
+  requireSuccess(await runCommand(process.execPath, [
+    join(consumerRoot, 'node_modules', 'typescript', 'bin', 'tsc'),
+    '--noEmit',
+    '--strict',
+    '--target', 'ES2022',
+    '--module', 'NodeNext',
+    '--moduleResolution', 'NodeNext',
+    typeVerifier,
+  ], { cwd: consumerRoot }), 'Verifying installed TypeScript declarations');
+}
+
+async function verifyInstalledPackageHygiene(consumerRoot) {
+  const packageRoot = join(consumerRoot, 'node_modules', '@oath-md', 'oath-mcp');
+  const files = await readdir(packageRoot, { recursive: true });
+  const normalized = files.map((path) => path.replaceAll('\\', '/'));
+  for (const required of ['LICENSE', 'NOTICE']) {
+    if (!normalized.includes(required)) throw new Error(`Installed package is missing ${required}`);
+  }
+  for (const path of normalized) {
+    if (/^(?:\.[^/]+|drafts|reports)(?:\/|$)/u.test(path)) {
+      throw new Error(`Installed package contains local workflow material: ${path}`);
+    }
+    if (/(?:^|\/)(?:private|credentials?)(?:\/|$)/iu.test(path)
+      || /(?:^|\/)\.env(?:\.|$)/iu.test(path)
+      || /(?:^|\/)[^/]*(?:credential|secret)[^/]*$/iu.test(path)) {
+      throw new Error(`Installed package contains a private or credential-like path: ${path}`);
+    }
+  }
+}
+
+function stdioTransport(consumerRoot) {
+  const command = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  return new StdioClientTransport({
+    command,
+    args: ['exec', '--offline', '--prefix', consumerRoot, '--', 'oath-mcp'],
+    cwd: consumerRoot,
+    stderr: 'pipe',
+  });
+}
+
+function expectSuccessfulCalculation(result, calculator) {
+  if (result?.isError === true || !Array.isArray(result?.structuredContent?.results)) {
+    throw new Error(`Installed ${calculator} calculation failed`);
+  }
+  if (result.structuredContent.id !== calculator) {
+    throw new Error(`Installed calculation returned the wrong calculator for ${calculator}`);
+  }
+}
+
+async function verifyModernClient(consumerRoot) {
+  const transport = stdioTransport(consumerRoot);
+  const client = new Client(
+    { name: 'oathmcp-packed-consumer-modern', version: '0.0.0' },
+    { versionNegotiation: { mode: { pin: MODERN_PROTOCOL_VERSION } } },
+  );
+  try {
+    await client.connect(transport);
+    const listed = await client.listTools();
+    const calculatorTools = listed.tools.filter(
+      ({ name }) => name.startsWith('calculate_') && name !== 'calculate_panel',
+    );
+    if (calculatorTools.length !== 40) {
+      throw new Error(`Installed catalog exposed ${calculatorTools.length} calculators; expected 40`);
+    }
+    for (const name of ['calculate_bmi', 'calculate_fib4', 'find_calculator', 'describe_calculator']) {
+      if (!listed.tools.some((tool) => tool.name === name)) throw new Error(`Installed catalog is missing ${name}`);
+    }
+    const bmi = await client.callTool({
+      name: 'calculate_bmi',
+      arguments: { weight_kg: 70, height_cm: 170 },
+    });
+    expectSuccessfulCalculation(bmi, 'bmi');
+    const fib4 = await client.callTool({
+      name: 'calculate_fib4',
+      arguments: {
+        age: 35,
+        ast: 75,
+        alt: 100,
+        platelet_count: 263,
+        assessment_context: 'stable_ambulatory',
+      },
+    });
+    expectSuccessfulCalculation(fib4, 'fib4');
+    const evidence = await client.readResource({ uri: 'calc://bmi/evidence' });
+    if (!Array.isArray(evidence.contents) || evidence.contents.length === 0) {
+      throw new Error('Installed BMI evidence resource was empty');
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+async function verifyLegacyClient(consumerRoot) {
+  const transport = stdioTransport(consumerRoot);
+  const client = new Client(
+    { name: 'oathmcp-packed-consumer-legacy', version: '0.0.0' },
+    { versionNegotiation: { mode: 'legacy' } },
+  );
+  try {
+    await client.connect(transport);
+    const listed = await client.listTools();
+    if (!listed.tools.some(({ name }) => name === 'calculate_bmi')) {
+      throw new Error('Installed legacy catalog is missing calculate_bmi');
+    }
+    const bmi = await client.callTool({
+      name: 'calculate_bmi',
+      arguments: { weight_kg: 70, height_cm: 170 },
+    });
+    expectSuccessfulCalculation(bmi, 'bmi');
+  } finally {
+    await client.close();
+  }
+}
+
+async function verifyRuntimeAudit(consumerRoot) {
+  const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const result = await runCommand(npm, ['audit', '--omit=dev', '--audit-level=low', '--json'], {
+    cwd: consumerRoot,
+    env: { ...process.env, npm_config_dry_run: 'false' },
+  });
+  let audit;
+  try {
+    audit = JSON.parse(result.stdout);
+  } catch {
+    throw new Error(`Installed runtime audit returned invalid JSON: ${result.stderr.trim()}`);
+  }
+  const total = audit?.metadata?.vulnerabilities?.total;
+  if (result.exitCode !== 0 || total !== 0) {
+    throw new Error(`Installed runtime audit reported ${String(total)} vulnerabilities`);
+  }
+}
+
+export async function verifyPackageConsumer({ packageSpec } = {}) {
+  const temporaryRoot = await mkdtemp(join(tmpdir(), 'oathmcp-package-consumer-'));
+  const consumerRoot = join(temporaryRoot, 'consumer');
+  try {
+    await mkdir(consumerRoot);
+    await writeFile(join(consumerRoot, 'package.json'), `${JSON.stringify({
+      name: 'oathmcp-package-consumer',
+      private: true,
+      type: 'module',
+      devDependencies: {
+        '@types/node': '^22',
+        typescript: '^5',
+      },
+    }, null, 2)}\n`, 'utf8');
+    const installSpec = packageSpec ?? await packLocalPackage(temporaryRoot);
+    const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+    requireSuccess(await runCommand(npm, [
+      'install', '--ignore-scripts', '--no-fund', installSpec,
+    ], {
+      cwd: consumerRoot,
+      env: { ...process.env, npm_config_dry_run: 'false' },
+    }), 'Installing the release candidate');
+    const installed = JSON.parse(await readFile(join(
+      consumerRoot, 'node_modules', '@oath-md', 'oath-mcp', 'package.json',
+    ), 'utf8'));
+    if (installed.name !== PACKAGE_NAME) throw new Error(`Installed package name was ${String(installed.name)}`);
+    if (installed.bin?.['oath-mcp'] !== 'dist/server/stdio.js') {
+      throw new Error('Installed package did not expose the oath-mcp executable');
+    }
+    await verifyInstalledPackageHygiene(consumerRoot);
+    await verifyExports(consumerRoot);
+    await verifyModernClient(consumerRoot);
+    await verifyLegacyClient(consumerRoot);
+    await verifyRuntimeAudit(consumerRoot);
+    console.log(
+      `Packed consumer verification passed: ${PACKAGE_NAME}@${installed.version}; ` +
+      '40 calculators; modern and legacy stdio; exports and declarations; ' +
+      'evidence; package hygiene; runtime audit.',
+    );
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true });
+  }
+}
+
+async function runCli() {
+  await verifyPackageConsumer(parseArgs(process.argv.slice(2)));
+}
+
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  await runCli();
+}

--- a/src/cli/prepare-release.test.ts
+++ b/src/cli/prepare-release.test.ts
@@ -38,10 +38,10 @@ describe('release preparation', () => {
   });
 
   it('keeps package and lockfile versions aligned', () => {
-    expect(JSON.parse(updatePackageVersion('{"name":"oath-mcp","version":"0.1.0"}', '0.2.0')))
-      .toMatchObject({ name: 'oath-mcp', version: '0.2.0' });
+    expect(JSON.parse(updatePackageVersion('{"name":"@oath-md/oath-mcp","version":"0.1.0"}', '0.2.0')))
+      .toMatchObject({ name: '@oath-md/oath-mcp', version: '0.2.0' });
     expect(JSON.parse(updatePackageVersion(
-      '{"name":"oath-mcp","version":"0.1.0","packages":{"":{"version":"0.1.0"}}}',
+      '{"name":"@oath-md/oath-mcp","version":"0.1.0","packages":{"":{"version":"0.1.0"}}}',
       '0.2.0',
       true,
     ))).toMatchObject({

--- a/src/server/stdio.ts
+++ b/src/server/stdio.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Stdio entry — the `oath-mcp` bin, for local clients
- * (`npx oath-mcp` / `{ command, args }` client configs).
+ * (`npx @oath-md/oath-mcp` / `{ command, args }` client configs).
  */
 import { serveStdio } from '@modelcontextprotocol/server/stdio';
 import { buildServer, catalogMode } from './build-tools.js';

--- a/test/ci-workflows.test.ts
+++ b/test/ci-workflows.test.ts
@@ -19,6 +19,7 @@ interface Workflow {
     if?: string;
     needs?: string | string[];
     environment?: string | { name?: string; url?: string };
+    strategy?: { matrix?: { 'node-version'?: number[] } };
     'timeout-minutes'?: number;
     steps?: Array<{ run?: string }>;
   }>;
@@ -50,6 +51,8 @@ describe('GitHub workflow boundaries', () => {
     ]));
     expect(runCommands(workflow)).not.toContain('npm run check:clinical-release');
     expect(runCommands(workflow, 'docs')).toContain('npm run check');
+    expect(workflow.jobs['package-consumer']?.strategy?.matrix?.['node-version']).toEqual([22, 24]);
+    expect(runCommands(workflow, 'package-consumer')).toContain('npm run check:package-consumer');
   });
 
   it('validates, deploys both Workers, verifies production, and publishes only from version tags', () => {
@@ -69,7 +72,7 @@ describe('GitHub workflow boundaries', () => {
       'npm run check:worker',
     ]));
     expect(commands.some((command) => command.includes('npm run deploy:production'))).toBe(true);
-    expect(commands.some((command) => command.includes('npm publish --access public'))).toBe(true);
+    expect(commands.some((command) => command.includes('npm run publish:npm'))).toBe(true);
     expect(commands.some((command) => command.includes('npm run check:release-metadata -- --tag'))).toBe(true);
     expect(commands.some((command) => command.includes('git merge-base --is-ancestor'))).toBe(true);
     expect(commands.some((command) => command.includes('npx wrangler deploy'))).toBe(false);
@@ -84,7 +87,16 @@ describe('GitHub workflow boundaries', () => {
     expect(workflow.jobs['deploy-production']?.needs).toBe('validate-release');
     expect(workflow.jobs['verify-production']).toBeUndefined();
     expect(workflow.jobs['publish-npm']?.needs).toBe('deploy-production');
-    expect(workflow.jobs['publish-npm']?.if).toContain('NPM_PUBLISH_ENABLED');
+    expect(workflow.jobs['publish-npm']?.if).not.toContain('NPM_PUBLISH_ENABLED');
+    expect(workflow.jobs['publish-npm']?.environment).toBe('npm-publish');
+    expect(workflow.jobs['rollback-after-npm-failure']?.needs).toEqual([
+      'deploy-production',
+      'publish-npm',
+    ]);
+    expect(runCommands(workflow, 'rollback-after-npm-failure'))
+      .toEqual(expect.arrayContaining([expect.stringContaining('npm run rollback:production')]));
+    expect(runCommands(workflow, 'publish-github-release'))
+      .toEqual(expect.arrayContaining([expect.stringContaining('PACKAGE_TARBALL')]));
     expect(workflow.jobs['deploy-production']?.environment).toMatchObject({ name: 'production' });
     expect(workflow.jobs['deploy-production']?.['timeout-minutes']).toBeGreaterThanOrEqual(45);
   });

--- a/test/package-manifest.test.ts
+++ b/test/package-manifest.test.ts
@@ -8,6 +8,7 @@ interface PackManifest {
 }
 
 interface PackageJson {
+  name: string;
   bundledDependencies?: string[];
   bundleDependencies?: string[];
   dependencies: Record<string, string>;
@@ -16,6 +17,7 @@ interface PackageJson {
   optionalDependencies?: Record<string, string>;
   overrides?: Record<string, unknown>;
   peerDependencies?: Record<string, string>;
+  publishConfig?: { access?: string; registry?: string };
 }
 
 interface PackageLock {
@@ -63,6 +65,11 @@ describe('published package manifest', () => {
     ]) expect(files).toContain(publicDocument);
 
     const packageJson = JSON.parse(readFileSync('package.json', 'utf8')) as PackageJson;
+    expect(packageJson.name).toBe('@oath-md/oath-mcp');
+    expect(packageJson.publishConfig).toEqual({
+      access: 'public',
+      registry: 'https://registry.npmjs.org/',
+    });
     expect(packageJson.dependencies).toMatchObject({
       '@modelcontextprotocol/express': '^2.0.0',
       '@modelcontextprotocol/node': '^2.0.0',

--- a/test/release/deploy-production.test.ts
+++ b/test/release/deploy-production.test.ts
@@ -8,6 +8,7 @@ import {
   deployProduction,
   parseActiveVersion,
   parseUploadedVersionId,
+  restoreProduction,
   runWranglerCommand,
 } from '../../scripts/release/deploy-production.mjs';
 
@@ -248,6 +249,31 @@ describe('rollback-safe production deployment', () => {
     const harness = createHarness({ splitMcp: true });
     await expect(execute(harness)).rejects.toThrow('exactly one active production version');
     expect(harness.events.some((event) => event.includes(':versions upload'))).toBe(false);
+  });
+
+  it('restores both captured Workers after a later npm publication failure', async () => {
+    const harness = createHarness();
+    harness.active.mcp = UPLOADED.mcp;
+    harness.active.docs = UPLOADED.docs;
+    await restoreProduction({
+      tag: 'v0.2.0',
+      sha: SHA,
+      mcpVersionId: PREVIOUS.mcp,
+      docsVersionId: PREVIOUS.docs,
+      expectedVersion: '0.1.0',
+    }, {
+      runWrangler: harness.runWrangler,
+      verifyRollbackImpl: harness.verifyRollbackImpl,
+      log: vi.fn(),
+    });
+    const rollbacks = harness.events.filter((event) => event.includes(':rollback '));
+    expect(rollbacks).toEqual([
+      expect.stringContaining(`mcp:rollback ${PREVIOUS.mcp}`),
+      expect.stringContaining(`docs:rollback ${PREVIOUS.docs}`),
+    ]);
+    expect(harness.verifyRollbackImpl).toHaveBeenCalledWith(expect.objectContaining({
+      expectedVersion: '0.1.0',
+    }));
   });
 });
 

--- a/test/release/publish-npm.test.ts
+++ b/test/release/publish-npm.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  parsePublishArgs,
+  publishNpm,
+  validatePublishedVersion,
+} from '../../scripts/release/publish-npm.mjs';
+
+const PACKAGE_NAME = '@oath-md/oath-mcp';
+const VERSION = '0.2.0';
+const SHA = 'a'.repeat(40);
+const TARBALL = 'https://registry.npmjs.org/@oath-md/oath-mcp/-/oath-mcp-0.2.0.tgz';
+const INTEGRITY = `sha512-${Buffer.from('integrity').toString('base64')}`;
+
+function packument({
+  gitHead = SHA,
+  latest = VERSION,
+}: { gitHead?: string; latest?: string } = {}) {
+  return {
+    name: PACKAGE_NAME,
+    'dist-tags': { latest },
+    versions: {
+      [VERSION]: {
+        name: PACKAGE_NAME,
+        version: VERSION,
+        gitHead,
+        dist: { integrity: INTEGRITY, tarball: TARBALL },
+      },
+    },
+  };
+}
+
+function response(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function harness(responses: Response[]) {
+  const fetchImpl = vi.fn(async () => responses.shift() ?? response(packument()));
+  const runNpm = vi.fn(async () => ({ exitCode: 0, stderr: '', stdout: '+ published' }));
+  const writeOutputs = vi.fn(async () => undefined);
+  return {
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+    runNpm,
+    sleep: vi.fn(async () => undefined),
+    writeOutputs,
+    log: vi.fn(),
+  };
+}
+
+async function execute(testHarness: ReturnType<typeof harness>) {
+  return publishNpm(
+    { sha: SHA, timeoutMs: 100, githubOutput: '/tmp/github-output' },
+    testHarness,
+  );
+}
+
+describe('npm release publication', () => {
+  it('requires an exact release commit', () => {
+    expect(parsePublishArgs(['--sha', SHA])).toEqual({ sha: SHA });
+    expect(() => parsePublishArgs(['--sha', 'abc'])).toThrow('full 40-character');
+  });
+
+  it('accepts an existing version from the exact release commit', async () => {
+    const testHarness = harness([response(packument())]);
+    await expect(execute(testHarness)).resolves.toMatchObject({
+      package_name: PACKAGE_NAME,
+      package_version: VERSION,
+      package_integrity: INTEGRITY,
+      package_tarball: TARBALL,
+    });
+    expect(testHarness.runNpm).not.toHaveBeenCalled();
+    expect(testHarness.writeOutputs).toHaveBeenCalledOnce();
+  });
+
+  it('publishes one absent version and waits for registry confirmation', async () => {
+    const testHarness = harness([
+      response({ name: PACKAGE_NAME, 'dist-tags': {}, versions: {} }),
+      response(packument()),
+    ]);
+    await expect(execute(testHarness)).resolves.toMatchObject({ package_version: VERSION });
+    expect(testHarness.runNpm).toHaveBeenCalledWith(expect.objectContaining({
+      args: ['publish', '--access', 'public'],
+    }));
+  });
+
+  it('waits until latest points to the release version', async () => {
+    const testHarness = harness([
+      response(packument({ latest: '0.1.0' })),
+      response(packument()),
+    ]);
+    await expect(execute(testHarness)).resolves.toMatchObject({ package_version: VERSION });
+    expect(testHarness.runNpm).not.toHaveBeenCalled();
+    expect(testHarness.fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('recovers when npm reports failure after the registry accepts the package', async () => {
+    const testHarness = harness([
+      response({}, 404),
+      response(packument()),
+    ]);
+    testHarness.runNpm.mockResolvedValueOnce({ exitCode: 1, stderr: 'network error', stdout: '' });
+    await expect(execute(testHarness)).resolves.toMatchObject({ package_version: VERSION });
+  });
+
+  it('rejects an immutable version published from another commit', async () => {
+    const testHarness = harness([response(packument({ gitHead: 'b'.repeat(40) }))]);
+    await expect(execute(testHarness)).rejects.toThrow('was published from');
+    expect(testHarness.runNpm).not.toHaveBeenCalled();
+  });
+
+  it('fails when neither publishing nor bounded registry confirmation succeeds', async () => {
+    const testHarness = harness(Array.from({ length: 20 }, () => response({}, 404)));
+    testHarness.runNpm.mockResolvedValueOnce({ exitCode: 1, stderr: 'denied', stdout: '' });
+    testHarness.sleep.mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    await expect(publishNpm(
+      { sha: SHA, timeoutMs: 1, githubOutput: undefined },
+      testHarness,
+    )).rejects.toThrow('did not confirm');
+    expect(testHarness.runNpm).toHaveBeenCalledOnce();
+    expect(testHarness.writeOutputs).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the registry cannot be read', async () => {
+    const testHarness = harness([response({}, 503)]);
+    await expect(execute(testHarness)).rejects.toThrow('npm registry returned HTTP 503');
+    expect(testHarness.runNpm).not.toHaveBeenCalled();
+  });
+});
+
+describe('published registry metadata', () => {
+  it('requires integrity, a registry tarball, and the latest dist-tag', () => {
+    expect(validatePublishedVersion(packument(), {
+      packageName: PACKAGE_NAME,
+      version: VERSION,
+      sha: SHA,
+    })).toEqual({ integrity: INTEGRITY, tarball: TARBALL });
+    expect(validatePublishedVersion(packument({ latest: '0.1.0' }), {
+      packageName: PACKAGE_NAME,
+      version: VERSION,
+      sha: SHA,
+    })).toEqual({ pendingLatest: true });
+  });
+});


### PR DESCRIPTION
## Summary

- publish future releases as `@oath-md/oath-mcp` while preserving the `oath-mcp` executable, Worker names, hosted route, server metadata, and clinical behavior
- verify the packed package from a clean project on Node 22 and 24, including both public exports and declarations, modern and legacy MCP clients, the 40-calculator catalog, BMI, FIB-4, evidence, package hygiene, and the runtime audit
- make npm publication mandatory after the verified Cloudflare cutover, verify exact registry metadata, attach the registry tarball to the GitHub release, and expose protected restoration of the captured Worker baseline if publication fails

## Release safety

- npm publishing uses GitHub OIDC through a dedicated protected environment; no npm token is stored
- the GitHub release is withheld until npm reports the exact tag commit, latest dist-tag, tarball URL, and SHA-512 integrity and the clean registry consumer passes
- publication is idempotent for an already-published exact version and fails closed on a mismatched commit or registry failure
- the first public package will be published interactively from the exact 0.2.1 tag before trusted publishing is enabled

## Verification

- `npm run check`
- `npm run check:release`
- `npm run check:worker`
- `npm run check:deploy`
- `npm publish --dry-run --access public`
- `npm run check:package-consumer`
- root runtime audit: 0 vulnerabilities
- Blume build and content checks: 40 calculators and 75 pages
