### PR TITLE
fix: verify npm releases by package integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to OathMCP are documented here.
 
 ## Unreleased
 
+- Verify npm releases by matching registry SHA-512 integrity to a dry-run pack
+  of the exact tag, while retaining commit checks when npm supplies optional
+  `gitHead` metadata.
+
 ## 0.2.1 — 2026-08-15
 
 - Published the first public npm package as `@oath-md/oath-mcp`, while

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -194,8 +194,10 @@ It uses the separately protected `npm-publish` environment and a
 [trusted publisher](https://docs.npmjs.com/trusted-publishers/) bound to this
 exact workflow. Trusted publishing uses GitHub OIDC; never add a long-lived npm
 token to the repository. The GitHub release remains withheld until the registry
-reports the exact package version, tag commit, latest dist-tag, tarball, and
-integrity and a clean registry consumer passes.
+reports the exact package version, latest dist-tag, and tarball integrity that
+matches a dry-run pack of the exact tag, and a clean registry consumer passes.
+If npm reports optional `gitHead` metadata, it must also match the tag commit;
+the registry does not guarantee that field for every publication.
 
 The first publication (`0.2.1`) is the one exception because npm requires a
 package to exist before trusted publishing can be configured. After the tagged
@@ -246,7 +248,7 @@ The [live service metadata](https://mcp.oath.md/health) is the source of truth
 for the deployed version, and [GitHub Releases](https://github.com/OATH-md/OathMCP/releases)
 identifies its exact tag and source. The npm registry is the source of truth for
 the scoped package. The `0.2.1` attestation covers the 40-calculator catalog,
-including FIB-4. Treat `0.2.1` as released only when the tag workflow has
+including FIB-4. Treat `0.2.1` as released only when the release process has
 verified both production Workers, verified `@oath-md/oath-mcp@0.2.1`, and
 created the matching GitHub release. The historical `0.2.0` package was not
 published to npm.

--- a/scripts/release/publish-npm.d.mts
+++ b/scripts/release/publish-npm.d.mts
@@ -30,9 +30,23 @@ export function readRegistryPackage(options: {
   registry?: string;
   fetchImpl?: typeof fetch;
 }): Promise<NpmPackument | undefined>;
+export function parseLocalPackIntegrity(
+  stdout: string,
+  expected: { packageName: string; version: string },
+): string;
+export function readLocalPackageIntegrity(options: {
+  packageName: string;
+  version: string;
+  projectRoot: string;
+  runNpm: (options: {
+    args: string[];
+    cwd: string;
+    streamOutput?: boolean;
+  }) => Promise<NpmCommandResult>;
+}): Promise<string>;
 export function validatePublishedVersion(
   packument: NpmPackument | undefined,
-  expected: { packageName: string; version: string; sha: string },
+  expected: { packageName: string; version: string; sha: string; integrity: string },
 ): { integrity: string; tarball: string } | { pendingLatest: true } | undefined;
 export function publishNpm(
   options: {
@@ -43,7 +57,11 @@ export function publishNpm(
   },
   dependencies?: {
     fetchImpl?: typeof fetch;
-    runNpm?: (options: { args: string[]; cwd: string }) => Promise<NpmCommandResult>;
+    runNpm?: (options: {
+      args: string[];
+      cwd: string;
+      streamOutput?: boolean;
+    }) => Promise<NpmCommandResult>;
     sleep?: (milliseconds: number) => Promise<void>;
     writeOutputs?: (path: string | undefined, values: PublishOutputs) => Promise<void>;
     log?: (message: string) => void;

--- a/scripts/release/publish-npm.mjs
+++ b/scripts/release/publish-npm.mjs
@@ -38,6 +38,7 @@ export function runNpmCommand({
   env = process.env,
   spawnImpl = spawn,
   stderr = process.stderr,
+  streamOutput = true,
   stdout = process.stdout,
   timeoutMs = 600_000,
 }) {
@@ -59,12 +60,12 @@ export function runNpmCommand({
   child.stdout.on('data', (chunk) => {
     const text = chunk.toString();
     stdoutOutput += text;
-    stdout.write(text);
+    if (streamOutput) stdout.write(text);
   });
   child.stderr.on('data', (chunk) => {
     const text = chunk.toString();
     stderrOutput += text;
-    stderr.write(text);
+    if (streamOutput) stderr.write(text);
   });
   return new Promise((resolvePromise, reject) => {
     child.once('error', (error) => {
@@ -106,13 +107,18 @@ export async function readRegistryPackage({
   return response.json();
 }
 
-export function validatePublishedVersion(packument, { packageName, version, sha }) {
+export function validatePublishedVersion(packument, {
+  packageName,
+  version,
+  sha,
+  integrity: expectedIntegrity,
+}) {
   const published = packument?.versions?.[version];
   if (published === undefined) return undefined;
   if (published.name !== packageName || published.version !== version) {
     throw new Error(`npm registry returned unexpected metadata for ${packageName}@${version}`);
   }
-  if (published.gitHead !== sha) {
+  if (published.gitHead !== undefined && published.gitHead !== sha) {
     throw new Error(
       `${packageName}@${version} was published from ${String(published.gitHead)}; expected ${sha}`,
     );
@@ -122,6 +128,11 @@ export function validatePublishedVersion(packument, { packageName, version, sha 
   if (typeof integrity !== 'string' || !integrity.startsWith('sha512-')) {
     throw new Error(`${packageName}@${version} is missing SHA-512 registry integrity`);
   }
+  if (integrity !== expectedIntegrity) {
+    throw new Error(
+      `${packageName}@${version} registry integrity does not match the exact release package`,
+    );
+  }
   if (typeof tarball !== 'string' || !tarball.startsWith('https://registry.npmjs.org/')) {
     throw new Error(`${packageName}@${version} is missing its registry tarball URL`);
   }
@@ -129,6 +140,36 @@ export function validatePublishedVersion(packument, { packageName, version, sha 
     return { pendingLatest: true };
   }
   return { integrity, tarball };
+}
+
+export function parseLocalPackIntegrity(stdout, { packageName, version }) {
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    throw new Error('npm pack did not return valid JSON');
+  }
+  const entries = Array.isArray(parsed) ? parsed : Object.values(parsed ?? {});
+  const packed = entries.find((entry) => entry?.name === packageName && entry?.version === version);
+  if (packed === undefined) {
+    throw new Error(`npm pack did not return ${packageName}@${version}`);
+  }
+  if (typeof packed.integrity !== 'string' || !packed.integrity.startsWith('sha512-')) {
+    throw new Error(`npm pack did not return SHA-512 integrity for ${packageName}@${version}`);
+  }
+  return packed.integrity;
+}
+
+export async function readLocalPackageIntegrity({ packageName, projectRoot, runNpm, version }) {
+  const build = await runNpm({ args: ['run', 'build'], cwd: projectRoot });
+  if (build.exitCode !== 0) throw new Error(`npm run build failed with exit code ${build.exitCode}`);
+  const packed = await runNpm({
+    args: ['pack', '--dry-run', '--json'],
+    cwd: projectRoot,
+    streamOutput: false,
+  });
+  if (packed.exitCode !== 0) throw new Error(`npm pack failed with exit code ${packed.exitCode}`);
+  return parseLocalPackIntegrity(packed.stdout, { packageName, version });
 }
 
 function delay(ms) {
@@ -171,7 +212,18 @@ export async function publishNpm({
 } = {}) {
   if (!/^[0-9a-f]{40}$/iu.test(sha ?? '')) throw new Error('A full release commit SHA is required');
   const metadata = await readPackageMetadata(projectRoot);
-  const expected = { packageName: metadata.name, version: metadata.version, sha };
+  const localIntegrity = await readLocalPackageIntegrity({
+    packageName: metadata.name,
+    projectRoot,
+    runNpm,
+    version: metadata.version,
+  });
+  const expected = {
+    integrity: localIntegrity,
+    packageName: metadata.name,
+    version: metadata.version,
+    sha,
+  };
   let packument = await readRegistryPackage({
     packageName: metadata.name,
     registry: metadata.registry,
@@ -190,7 +242,9 @@ export async function publishNpm({
       log(`${publishFailure.message}; checking whether the registry accepted the package.`);
     }
   } else if (!published.pendingLatest) {
-    log(`${metadata.name}@${metadata.version} is already published from ${sha}.`);
+    log(
+      `${metadata.name}@${metadata.version} already matches the exact release package from ${sha}.`,
+    );
   }
 
   const deadline = Date.now() + timeoutMs;

--- a/test/release/publish-npm.test.ts
+++ b/test/release/publish-npm.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  parseLocalPackIntegrity,
   parsePublishArgs,
   publishNpm,
   validatePublishedVersion,
@@ -14,9 +15,10 @@ const TARBALL = `https://registry.npmjs.org/@oath-md/oath-mcp/-/oath-mcp-${VERSI
 const INTEGRITY = `sha512-${Buffer.from('integrity').toString('base64')}`;
 
 function packument({
-  gitHead = SHA,
+  gitHead,
+  integrity = INTEGRITY,
   latest = VERSION,
-}: { gitHead?: string; latest?: string } = {}) {
+}: { gitHead?: string; integrity?: string; latest?: string } = {}) {
   return {
     name: PACKAGE_NAME,
     'dist-tags': { latest },
@@ -24,8 +26,8 @@ function packument({
       [VERSION]: {
         name: PACKAGE_NAME,
         version: VERSION,
-        gitHead,
-        dist: { integrity: INTEGRITY, tarball: TARBALL },
+        ...(gitHead === undefined ? {} : { gitHead }),
+        dist: { integrity, tarball: TARBALL },
       },
     },
   };
@@ -40,7 +42,19 @@ function response(body: unknown, status = 200): Response {
 
 function harness(responses: Response[]) {
   const fetchImpl = vi.fn(async () => responses.shift() ?? response(packument()));
-  const runNpm = vi.fn(async () => ({ exitCode: 0, stderr: '', stdout: '+ published' }));
+  const runNpm = vi.fn(async ({ args }: { args: string[] }) => ({
+    exitCode: 0,
+    stderr: '',
+    stdout: args[0] === 'pack'
+      ? JSON.stringify({
+          [PACKAGE_NAME]: {
+            name: PACKAGE_NAME,
+            version: VERSION,
+            integrity: INTEGRITY,
+          },
+        })
+      : '+ published',
+  }));
   const writeOutputs = vi.fn(async () => undefined);
   return {
     fetchImpl: fetchImpl as unknown as typeof fetch,
@@ -72,7 +86,7 @@ describe('npm release publication', () => {
       package_integrity: INTEGRITY,
       package_tarball: TARBALL,
     });
-    expect(testHarness.runNpm).not.toHaveBeenCalled();
+    expect(testHarness.runNpm).toHaveBeenCalledTimes(2);
     expect(testHarness.writeOutputs).toHaveBeenCalledOnce();
   });
 
@@ -93,7 +107,7 @@ describe('npm release publication', () => {
       response(packument()),
     ]);
     await expect(execute(testHarness)).resolves.toMatchObject({ package_version: VERSION });
-    expect(testHarness.runNpm).not.toHaveBeenCalled();
+    expect(testHarness.runNpm).toHaveBeenCalledTimes(2);
     expect(testHarness.fetchImpl).toHaveBeenCalledTimes(2);
   });
 
@@ -102,19 +116,37 @@ describe('npm release publication', () => {
       response({}, 404),
       response(packument()),
     ]);
-    testHarness.runNpm.mockResolvedValueOnce({ exitCode: 1, stderr: 'network error', stdout: '' });
+    testHarness.runNpm.mockImplementation(async ({ args }: { args: string[] }) => ({
+      exitCode: args[0] === 'publish' ? 1 : 0,
+      stderr: args[0] === 'publish' ? 'network error' : '',
+      stdout: args[0] === 'pack'
+        ? JSON.stringify([{ name: PACKAGE_NAME, version: VERSION, integrity: INTEGRITY }])
+        : '',
+    }));
     await expect(execute(testHarness)).resolves.toMatchObject({ package_version: VERSION });
   });
 
   it('rejects an immutable version published from another commit', async () => {
     const testHarness = harness([response(packument({ gitHead: 'b'.repeat(40) }))]);
     await expect(execute(testHarness)).rejects.toThrow('was published from');
-    expect(testHarness.runNpm).not.toHaveBeenCalled();
+    expect(testHarness.runNpm).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects an immutable version with different package content', async () => {
+    const testHarness = harness([response(packument({ integrity: 'sha512-different' }))]);
+    await expect(execute(testHarness)).rejects.toThrow('exact release package');
+    expect(testHarness.runNpm).toHaveBeenCalledTimes(2);
   });
 
   it('fails when neither publishing nor bounded registry confirmation succeeds', async () => {
     const testHarness = harness(Array.from({ length: 20 }, () => response({}, 404)));
-    testHarness.runNpm.mockResolvedValueOnce({ exitCode: 1, stderr: 'denied', stdout: '' });
+    testHarness.runNpm.mockImplementation(async ({ args }: { args: string[] }) => ({
+      exitCode: args[0] === 'publish' ? 1 : 0,
+      stderr: args[0] === 'publish' ? 'denied' : '',
+      stdout: args[0] === 'pack'
+        ? JSON.stringify([{ name: PACKAGE_NAME, version: VERSION, integrity: INTEGRITY }])
+        : '',
+    }));
     testHarness.sleep.mockImplementation(async () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
     });
@@ -122,14 +154,14 @@ describe('npm release publication', () => {
       { sha: SHA, timeoutMs: 1, githubOutput: undefined },
       testHarness,
     )).rejects.toThrow('did not confirm');
-    expect(testHarness.runNpm).toHaveBeenCalledOnce();
+    expect(testHarness.runNpm).toHaveBeenCalledTimes(3);
     expect(testHarness.writeOutputs).not.toHaveBeenCalled();
   });
 
   it('fails closed when the registry cannot be read', async () => {
     const testHarness = harness([response({}, 503)]);
     await expect(execute(testHarness)).rejects.toThrow('npm registry returned HTTP 503');
-    expect(testHarness.runNpm).not.toHaveBeenCalled();
+    expect(testHarness.runNpm).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -139,11 +171,20 @@ describe('published registry metadata', () => {
       packageName: PACKAGE_NAME,
       version: VERSION,
       sha: SHA,
+      integrity: INTEGRITY,
     })).toEqual({ integrity: INTEGRITY, tarball: TARBALL });
     expect(validatePublishedVersion(packument({ latest: '0.1.0' }), {
       packageName: PACKAGE_NAME,
       version: VERSION,
       sha: SHA,
+      integrity: INTEGRITY,
     })).toEqual({ pendingLatest: true });
+  });
+
+  it('accepts npm 10 arrays and npm 12 package-keyed pack output', () => {
+    const expected = { packageName: PACKAGE_NAME, version: VERSION };
+    const entry = { name: PACKAGE_NAME, version: VERSION, integrity: INTEGRITY };
+    expect(parseLocalPackIntegrity(JSON.stringify([entry]), expected)).toBe(INTEGRITY);
+    expect(parseLocalPackIntegrity(JSON.stringify({ [PACKAGE_NAME]: entry }), expected)).toBe(INTEGRITY);
   });
 });


### PR DESCRIPTION
## Summary

- compare registry SHA-512 integrity with a dry-run pack of the exact release source
- retain fail-closed commit validation when npm supplies optional gitHead metadata
- support npm 10 and npm 12 pack output formats and document the registry contract

## Verification

- npm run check:release
- 55 test files and 1,346 tests
- live registry verification against the detached v0.2.1 source
- confirmed rejection when package bytes differ from the release source